### PR TITLE
feat: add project filtering (Phase 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,54 +15,64 @@ Standalone fork of @modelcontextprotocol/server-memory. Provides persistent memo
 
 The server is split across 4 source files:
 
-### `types.ts` (~96 lines)
+### `types.ts` (~113 lines)
 - Defines the `Entity`, `Relation`, `KnowledgeGraph`, and `Observation` types
+- `Entity.project: string | null` — scopes the entity to a project (`null` = global, never `undefined`)
+- `CreateEntitiesResult` and `SkippedEntity` types — collision reporting when entity names already exist
 - Defines the `GraphStore` interface — the contract both storage backends must implement
 - All CRUD methods are declared here; both `JsonlStore` and `SqliteStore` implement this interface
 - `Observation` type: `{ content: string; createdAt: string }` — each observation carries an ISO 8601 UTC timestamp (or `'unknown'` for data migrated from old string format)
 
-### `jsonl-store.ts` (~322 lines)
+### `jsonl-store.ts` (~434 lines)
 - `JsonlStore` class: JSONL flat-file backend (renamed from `KnowledgeGraphManager`)
 - Implements the `GraphStore` interface
+- Optional `project` field on entity JSONL lines (`null`/missing = global)
 - Atomic writes: saves to a `.tmp` file then uses `fs.rename` to swap it in — prevents partial writes from corrupting the file
 - `loadGraph()` uses per-line error isolation — malformed JSONL lines are logged to stderr and skipped, so one bad line doesn't kill the whole graph
 - Full graph is loaded from disk and saved back on every operation (no partial updates)
 
-### `sqlite-store.ts` (~270 lines)
+### `sqlite-store.ts` (~680 lines)
 - `SqliteStore` class: SQLite backend using `better-sqlite3`
 - Implements the `GraphStore` interface
+- `project TEXT` nullable column on entities table — `NULL` means global (visible to all projects)
+- Migration via `pragma('table_info(entities)')` for existing databases that lack the `project` column
+- `idx_entities_project` index for query performance on project-filtered reads
 - Opens the database with WAL mode (Write-Ahead Logging) — allows reads to proceed concurrently with writes
 - `foreign_keys = ON` is set per connection — SQLite does not enable FK constraints by default, so this must be set explicitly each time the connection opens
 - Deduplication is enforced at the database level via `UNIQUE` constraints on entity names, relation triples, and (entity + observation content) pairs — `INSERT OR IGNORE` silently skips duplicate inserts
 - Relations must reference existing entity names (FK constraints), so adding a relation with a missing endpoint throws rather than silently creating a dangling edge
 
-### `index.ts` (~300 lines)
+### `index.ts` (~381 lines)
 - Entry point: registers all MCP tools via `server.registerTool()`
 - `StoreConfig` type and `ensureMemoryFilePath()`: resolves the storage path from `MEMORY_FILE_PATH` env var and returns which store class to use
   - `.jsonl` extension → `JsonlStore`
   - `.db` or `.sqlite` extension → `SqliteStore`
   - No extension / omitted → defaults to `memory.db` (SQLite)
 - Auto-migration: on first run, if a `.db` path is requested but doesn't exist yet and a `.jsonl` file is found at the same base path, the server migrates all data from JSONL into SQLite in a single transaction, then renames the original `.jsonl` to `.jsonl.bak`
+- `normalizeProjectId()`: trims whitespace, lowercases, and converts empty/undefined to undefined (global scope)
 - `normalizeObservation()`: validates observation shape (structural check, not unsafe cast); throws on invalid format
 - `createObservation()`: creates new observations with current UTC timestamp
+- `projectId` optional parameter on `create_entities`, `read_graph`, `search_nodes`, `open_nodes` tools — scopes operations to a project
+- `list_projects` tool returns distinct project names from the store
 - MCP tools registered with separate input/output Zod schemas
 - Zod schemas enforce `.min(1)` on all string inputs, `.max(500)` on names / `.max(5000)` on observation content, and `.max(100)` on all input arrays
 - All dedup operations use Set-based O(1) lookups (entity names, JSON-serialized composite relation keys, observation content) with within-batch dedup (Sets updated during iteration)
 - Delete operations are idempotent (silently ignore missing targets); add operations throw on missing entities
 
 ## Known Limitations
+- **Entity names are globally unique** across all projects — permanent architectural constraint because relations use entity names as foreign keys
 - **JSONL backend**: no file locking for concurrent access; no FK validation that relation endpoints reference existing entities
 - **SQLite backend**: LIKE-based search is case-insensitive for ASCII only — non-ASCII Unicode characters (e.g. accented letters, CJK) may not match case-insensitively as expected
 
 ## Tests
-- `__tests__/knowledge-graph.test.ts` — parameterized suite (`describe.each`) running ~46 shared behavioral tests against both `JsonlStore` and `SqliteStore`, covering all CRUD operations, deduplication (within-entity, within-array, and within-batch), composite key safety, search, edge cases, observation timestamps, normalizeObservation validation, atomic writes (JSONL), and idempotent delete edge cases. Plus ~15 JSONL-specific tests (malformed line isolation, legacy .json migration) and ~8 SQLite-specific tests (FK enforcement, WAL mode, UNIQUE constraint dedup)
+- `__tests__/knowledge-graph.test.ts` — parameterized suite (`describe.each`) running ~60 shared behavioral tests against both `JsonlStore` and `SqliteStore`, covering all CRUD operations, deduplication (within-entity, within-array, and within-batch), composite key safety, search, edge cases, observation timestamps, normalizeObservation validation, atomic writes (JSONL), idempotent delete edge cases, project filtering (create with projectId, readGraph/searchNodes/openNodes scoping, listProjects, collision reporting via CreateEntitiesResult). Plus ~14 JSONL-specific tests (malformed line isolation, legacy .json migration) and ~9 SQLite-specific tests (FK enforcement, WAL mode, UNIQUE constraint dedup, project column migration)
 - `__tests__/file-path.test.ts` — 10 tests covering `StoreConfig` return type, extension routing (.jsonl / .db / .sqlite / default), and legacy .json→.jsonl migration
 - `__tests__/migration.test.ts` — 5 tests covering JSONL→SQLite auto-migration: data transfer, .jsonl.bak rename, idempotency when .db already exists, empty JSONL file handling
 
 ## Planned Phases
 1. ~~**Timestamps**~~ — DONE: observations are `{ content, createdAt }` objects; legacy string observations auto-migrate with `createdAt: 'unknown'`
 2. ~~**SQLite storage backend**~~ — DONE: SQLite default with JSONL fallback, GraphStore interface, auto-migration, FK constraints, parameterized tests
-3. **Project filtering** — scope entities to projects so multi-project memory stays clean
+3. ~~**Project filtering**~~ — DONE: optional projectId parameter on tools, project column in SQLite, collision reporting via CreateEntitiesResult
 4. **Pagination** — cursor-based pagination for read_graph and search_nodes
 
 ## Relevant Agents

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ The server is split across 4 source files:
 - Implements the `GraphStore` interface
 - `project TEXT` nullable column on entities table — `NULL` means global (visible to all projects)
 - Migration via `pragma('table_info(entities)')` for existing databases that lack the `project` column
-- `idx_entities_project` index for query performance on project-filtered reads
+- `idx_entities_project` and `idx_relations_to_entity` indexes for query performance on project-filtered reads and relation lookups
 - Opens the database with WAL mode (Write-Ahead Logging) — allows reads to proceed concurrently with writes
 - `foreign_keys = ON` is set per connection — SQLite does not enable FK constraints by default, so this must be set explicitly each time the connection opens
 - Deduplication is enforced at the database level via `UNIQUE` constraints on entity names, relation triples, and (entity + observation content) pairs — `INSERT OR IGNORE` silently skips duplicate inserts
@@ -49,7 +49,7 @@ The server is split across 4 source files:
   - `.db` or `.sqlite` extension → `SqliteStore`
   - No extension / omitted → defaults to `memory.db` (SQLite)
 - Auto-migration: on first run, if a `.db` path is requested but doesn't exist yet and a `.jsonl` file is found at the same base path, the server migrates all data from JSONL into SQLite in a single transaction, then renames the original `.jsonl` to `.jsonl.bak`
-- `normalizeProjectId()`: trims whitespace, lowercases, and converts empty/undefined to undefined (global scope)
+- `normalizeProjectId()`: trims whitespace, lowercases, NFC-normalizes Unicode, and converts empty/undefined to undefined (global scope)
 - `normalizeObservation()`: validates observation shape (structural check, not unsafe cast); throws on invalid format
 - `createObservation()`: creates new observations with current UTC timestamp
 - `projectId` optional parameter on `create_entities`, `read_graph`, `search_nodes`, `open_nodes` tools — scopes operations to a project
@@ -61,6 +61,7 @@ The server is split across 4 source files:
 
 ## Known Limitations
 - **Entity names are globally unique** across all projects — permanent architectural constraint because relations use entity names as foreign keys
+- **Project filtering is advisory, not a security boundary** — it scopes queries for convenience but does not enforce access control. Entity name collisions across projects are reported (not silently dropped), and global entities (project=null) are visible to all project-scoped queries by design.
 - **JSONL backend**: no file locking for concurrent access; no FK validation that relation endpoints reference existing entities
 - **SQLite backend**: LIKE-based search is case-insensitive for ASCII only — non-ASCII Unicode characters (e.g. accented letters, CJK) may not match case-insensitively as expected
 

--- a/__tests__/knowledge-graph.test.ts
+++ b/__tests__/knowledge-graph.test.ts
@@ -1385,4 +1385,68 @@ describe('SqliteStore-specific', () => {
 			expect(result[0].addedObservations[0].content).toBe('new one');
 		});
 	});
+
+	describe('project column migration', () => {
+		it('should migrate existing database by adding project column', async () => {
+			const migrationPath = path.join(testDir, `test-migration-project-${Date.now()}.db`);
+
+			// Create a pre-Phase-3 database manually (no project column).
+			// Imports better-sqlite3 directly to build a schema without the project column,
+			// simulating a database created before Phase 3 was implemented.
+			const Database = (await import('better-sqlite3')).default;
+			const rawDb = new Database(migrationPath);
+			rawDb.pragma('journal_mode = WAL');
+			rawDb.pragma('foreign_keys = ON');
+			rawDb.exec(`
+				CREATE TABLE IF NOT EXISTS entities (
+					id          INTEGER PRIMARY KEY AUTOINCREMENT,
+					name        TEXT NOT NULL UNIQUE,
+					entity_type TEXT NOT NULL
+				);
+				CREATE TABLE IF NOT EXISTS observations (
+					id          INTEGER PRIMARY KEY AUTOINCREMENT,
+					entity_id   INTEGER NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+					content     TEXT NOT NULL,
+					created_at  TEXT NOT NULL,
+					UNIQUE(entity_id, content)
+				);
+				CREATE TABLE IF NOT EXISTS relations (
+					id            INTEGER PRIMARY KEY AUTOINCREMENT,
+					from_entity   TEXT NOT NULL REFERENCES entities(name) ON DELETE CASCADE ON UPDATE CASCADE,
+					to_entity     TEXT NOT NULL REFERENCES entities(name) ON DELETE CASCADE ON UPDATE CASCADE,
+					relation_type TEXT NOT NULL,
+					UNIQUE(from_entity, to_entity, relation_type)
+				);
+			`);
+			// Insert a legacy entity without a project column
+			rawDb.prepare('INSERT INTO entities (name, entity_type) VALUES (?, ?)').run('OldEntity', 'test');
+			const entityId = (rawDb.prepare('SELECT id FROM entities WHERE name = ?').get('OldEntity') as { id: number }).id;
+			rawDb.prepare('INSERT INTO observations (entity_id, content, created_at) VALUES (?, ?, ?)').run(entityId, 'old data', new Date().toISOString());
+			rawDb.close();
+
+			// Re-open with SqliteStore -- init() should detect missing project column and add it
+			const store2 = new SqliteStore(migrationPath);
+			await store2.init();
+
+			// Old entity should have null project after migration
+			const graph = await store2.readGraph();
+			expect(graph.entities[0].project).toBeNull();
+
+			// Verify new entities can be created with a project
+			await store2.createEntities(
+				[{ name: 'NewEntity', entityType: 'test', observations: ['new data'] }],
+				'test-project'
+			);
+			// readGraph with project filter returns project entities + global (null project) entities
+			const graph2 = await store2.readGraph('test-project');
+			const names = graph2.entities.map(e => e.name).sort();
+			expect(names).toEqual(['NewEntity', 'OldEntity']); // OldEntity is global, included
+
+			await store2.close();
+			// Clean up all SQLite sidecar files
+			for (const suffix of ['', '-wal', '-shm']) {
+				try { await fs.unlink(migrationPath + suffix); } catch { /* ignore */ }
+			}
+		});
+	});
 });

--- a/__tests__/knowledge-graph.test.ts
+++ b/__tests__/knowledge-graph.test.ts
@@ -630,6 +630,63 @@ describe.each<[string, string, StoreFactory]>([
 			);
 		});
 
+		it('should exclude cross-project relations from searchNodes with projectId', async () => {
+			// Create entities in two projects plus a global entity
+			await store.createEntities(
+				[{ name: 'SearchP1', entityType: 'test', observations: ['searchable'] }],
+				'proj-1'
+			);
+			await store.createEntities(
+				[{ name: 'SearchP2', entityType: 'test', observations: ['searchable'] }],
+				'proj-2'
+			);
+			await store.createEntities([
+				{ name: 'SearchGlobal', entityType: 'test', observations: ['searchable'] },
+			]);
+			await store.createRelations([
+				{ from: 'SearchP1', to: 'SearchGlobal', relationType: 'uses' },
+				{ from: 'SearchP1', to: 'SearchP2', relationType: 'cross_project' },
+			]);
+
+			// searchNodes with proj-1 should return P1 + Global (both match "searchable"),
+			// and only the P1->Global relation (AND logic: both endpoints in result set)
+			const result = await store.searchNodes('searchable', 'proj-1');
+			const names = result.entities.map(e => e.name).sort();
+			expect(names).toEqual(['SearchGlobal', 'SearchP1']);
+			expect(result.relations).toHaveLength(1);
+			expect(result.relations[0]).toEqual(
+				expect.objectContaining({ from: 'SearchP1', to: 'SearchGlobal', relationType: 'uses' })
+			);
+		});
+
+		it('should exclude cross-project relations from openNodes with projectId', async () => {
+			// Create entities in two projects plus a global entity
+			await store.createEntities(
+				[{ name: 'OpenP1', entityType: 'test', observations: ['o1'] }],
+				'proj-1'
+			);
+			await store.createEntities(
+				[{ name: 'OpenP2', entityType: 'test', observations: ['o2'] }],
+				'proj-2'
+			);
+			await store.createEntities([
+				{ name: 'OpenGlobal', entityType: 'test', observations: ['og'] },
+			]);
+			await store.createRelations([
+				{ from: 'OpenP1', to: 'OpenGlobal', relationType: 'uses' },
+				{ from: 'OpenP1', to: 'OpenP2', relationType: 'cross_project' },
+			]);
+
+			// openNodes with proj-1 scope: request all 3 by name, should only get P1 + Global
+			const result = await store.openNodes(['OpenP1', 'OpenP2', 'OpenGlobal'], 'proj-1');
+			const names = result.entities.map(e => e.name).sort();
+			expect(names).toEqual(['OpenGlobal', 'OpenP1']);
+			expect(result.relations).toHaveLength(1);
+			expect(result.relations[0]).toEqual(
+				expect.objectContaining({ from: 'OpenP1', to: 'OpenGlobal', relationType: 'uses' })
+			);
+		});
+
 		it('should list distinct project names sorted alphabetically', async () => {
 			await store.createEntities(
 				[{ name: 'A', entityType: 'test', observations: ['a'] }],

--- a/__tests__/knowledge-graph.test.ts
+++ b/__tests__/knowledge-graph.test.ts
@@ -46,7 +46,7 @@ describe.each<[string, string, StoreFactory]>([
 	// ----------------------------------------------------------
 	describe('createEntities', () => {
 		it('should create new entities', async () => {
-			const newEntities = await store.createEntities([
+			const { created: newEntities } = await store.createEntities([
 				{ name: 'Alice', entityType: 'person', observations: ['works at Acme Corp'] },
 				{ name: 'Bob', entityType: 'person', observations: ['likes programming'] },
 			]);
@@ -65,7 +65,7 @@ describe.each<[string, string, StoreFactory]>([
 			await store.createEntities([
 				{ name: 'Alice', entityType: 'person', observations: ['works at Acme Corp'] },
 			]);
-			const newEntities = await store.createEntities([
+			const { created: newEntities } = await store.createEntities([
 				{ name: 'Alice', entityType: 'person', observations: ['works at Acme Corp'] },
 			]);
 
@@ -76,7 +76,7 @@ describe.each<[string, string, StoreFactory]>([
 		});
 
 		it('should handle empty entity arrays', async () => {
-			const newEntities = await store.createEntities([]);
+			const { created: newEntities } = await store.createEntities([]);
 			expect(newEntities).toHaveLength(0);
 		});
 	});
@@ -462,6 +462,217 @@ describe.each<[string, string, StoreFactory]>([
 	});
 
 	// ----------------------------------------------------------
+	// project filtering
+	// ----------------------------------------------------------
+	describe('project filtering', () => {
+		it('should tag entities with projectId on create', async () => {
+			const result = await store.createEntities(
+				[{ name: 'ProjectEntity', entityType: 'test', observations: ['obs1'] }],
+				'my-project'
+			);
+			expect(result.created).toHaveLength(1);
+			expect(result.created[0].project).toBe('my-project');
+			expect(result.skipped).toHaveLength(0);
+		});
+
+		it('should set project to null when projectId omitted', async () => {
+			const result = await store.createEntities([
+				{ name: 'GlobalEntity', entityType: 'test', observations: ['obs1'] },
+			]);
+			expect(result.created).toHaveLength(1);
+			expect(result.created[0].project).toBeNull();
+		});
+
+		it('should normalize projectId to lowercase and trimmed', async () => {
+			const result = await store.createEntities(
+				[{ name: 'NormEntity', entityType: 'test', observations: ['obs1'] }],
+				'  My-Project  '
+			);
+			expect(result.created[0].project).toBe('my-project');
+		});
+
+		it('should report skipped entities with existing project info', async () => {
+			await store.createEntities(
+				[{ name: 'Shared', entityType: 'test', observations: ['obs1'] }],
+				'project-a'
+			);
+			const result = await store.createEntities(
+				[{ name: 'Shared', entityType: 'test', observations: ['obs2'] }],
+				'project-b'
+			);
+			expect(result.created).toHaveLength(0);
+			expect(result.skipped).toHaveLength(1);
+			expect(result.skipped[0]).toEqual({ name: 'Shared', existingProject: 'project-a' });
+		});
+
+		it('should filter readGraph by project + globals', async () => {
+			await store.createEntities(
+				[{ name: 'A', entityType: 'test', observations: ['a'] }],
+				'proj-1'
+			);
+			await store.createEntities(
+				[{ name: 'B', entityType: 'test', observations: ['b'] }],
+				'proj-2'
+			);
+			await store.createEntities([
+				{ name: 'G', entityType: 'test', observations: ['global'] },
+			]);
+
+			const filtered = await store.readGraph('proj-1');
+			const names = filtered.entities.map(e => e.name).sort();
+			expect(names).toEqual(['A', 'G']);
+		});
+
+		it('should return entire graph when readGraph has no projectId', async () => {
+			await store.createEntities(
+				[{ name: 'A', entityType: 'test', observations: ['a'] }],
+				'proj-1'
+			);
+			await store.createEntities(
+				[{ name: 'B', entityType: 'test', observations: ['b'] }],
+				'proj-2'
+			);
+			await store.createEntities([
+				{ name: 'G', entityType: 'test', observations: ['global'] },
+			]);
+
+			const all = await store.readGraph();
+			expect(all.entities).toHaveLength(3);
+		});
+
+		it('should filter searchNodes by project + globals', async () => {
+			await store.createEntities(
+				[{ name: 'Alpha', entityType: 'test', observations: ['shared keyword'] }],
+				'proj-1'
+			);
+			await store.createEntities(
+				[{ name: 'Beta', entityType: 'test', observations: ['shared keyword'] }],
+				'proj-2'
+			);
+			await store.createEntities([
+				{ name: 'Gamma', entityType: 'test', observations: ['shared keyword'] },
+			]);
+
+			const result = await store.searchNodes('shared', 'proj-1');
+			const names = result.entities.map(e => e.name).sort();
+			expect(names).toEqual(['Alpha', 'Gamma']);
+		});
+
+		it('should search entire graph when searchNodes has no projectId', async () => {
+			await store.createEntities(
+				[{ name: 'Alpha', entityType: 'test', observations: ['keyword'] }],
+				'proj-1'
+			);
+			await store.createEntities(
+				[{ name: 'Beta', entityType: 'test', observations: ['keyword'] }],
+				'proj-2'
+			);
+
+			const result = await store.searchNodes('keyword');
+			expect(result.entities).toHaveLength(2);
+		});
+
+		it('should filter openNodes by project + globals', async () => {
+			await store.createEntities(
+				[{ name: 'X', entityType: 'test', observations: ['x'] }],
+				'proj-1'
+			);
+			await store.createEntities(
+				[{ name: 'Y', entityType: 'test', observations: ['y'] }],
+				'proj-2'
+			);
+			await store.createEntities([
+				{ name: 'Z', entityType: 'test', observations: ['z'] },
+			]);
+
+			const result = await store.openNodes(['X', 'Y', 'Z'], 'proj-1');
+			const names = result.entities.map(e => e.name).sort();
+			expect(names).toEqual(['X', 'Z']);
+		});
+
+		it('should return all requested entities when openNodes has no projectId', async () => {
+			await store.createEntities(
+				[{ name: 'X', entityType: 'test', observations: ['x'] }],
+				'proj-1'
+			);
+			await store.createEntities(
+				[{ name: 'Y', entityType: 'test', observations: ['y'] }],
+				'proj-2'
+			);
+
+			const result = await store.openNodes(['X', 'Y']);
+			expect(result.entities).toHaveLength(2);
+		});
+
+		it('should only include relations where both endpoints are in the result set', async () => {
+			await store.createEntities(
+				[{ name: 'P1', entityType: 'test', observations: ['p1'] }],
+				'proj-1'
+			);
+			await store.createEntities(
+				[{ name: 'P2', entityType: 'test', observations: ['p2'] }],
+				'proj-2'
+			);
+			await store.createEntities([
+				{ name: 'Global', entityType: 'test', observations: ['g'] },
+			]);
+			await store.createRelations([
+				{ from: 'P1', to: 'Global', relationType: 'uses' },
+				{ from: 'P1', to: 'P2', relationType: 'cross_project' },
+				{ from: 'P2', to: 'Global', relationType: 'also_uses' },
+			]);
+
+			const result = await store.readGraph('proj-1');
+			expect(result.entities.map(e => e.name).sort()).toEqual(['Global', 'P1']);
+			expect(result.relations).toHaveLength(1);
+			expect(result.relations[0]).toEqual(
+				expect.objectContaining({ from: 'P1', to: 'Global', relationType: 'uses' })
+			);
+		});
+
+		it('should list distinct project names sorted alphabetically', async () => {
+			await store.createEntities(
+				[{ name: 'A', entityType: 'test', observations: ['a'] }],
+				'zebra'
+			);
+			await store.createEntities(
+				[{ name: 'B', entityType: 'test', observations: ['b'] }],
+				'alpha'
+			);
+			await store.createEntities([
+				{ name: 'C', entityType: 'test', observations: ['c'] },
+			]);
+
+			const projects = await store.listProjects();
+			expect(projects).toEqual(['alpha', 'zebra']);
+		});
+
+		it('should return empty array from listProjects on empty database', async () => {
+			const projects = await store.listProjects();
+			expect(projects).toEqual([]);
+		});
+
+		it('should persist project field across store restarts', async () => {
+			await store.createEntities(
+				[{ name: 'Persistent', entityType: 'test', observations: ['data'] }],
+				'my-project'
+			);
+
+			await store.close();
+			const store2 = createStore(storePath);
+			await store2.init();
+			const graph = await store2.readGraph();
+			await store2.close();
+
+			// Re-open so afterEach can close and clean up normally
+			store = createStore(storePath);
+			await store.init();
+
+			expect(graph.entities[0].project).toBe('my-project');
+		});
+	});
+
+	// ----------------------------------------------------------
 	// observation timestamps (shared subset)
 	// ----------------------------------------------------------
 	describe('observation timestamps', () => {
@@ -567,7 +778,7 @@ describe.each<[string, string, StoreFactory]>([
 	describe('observation deduplication within createEntities', () => {
 		it('should deduplicate observations within a single entity', async () => {
 			// Previously this bug allowed ['a', 'a'] to create two identical observations
-			const entities = await store.createEntities([
+			const { created: entities } = await store.createEntities([
 				{ name: 'Alice', entityType: 'person', observations: ['same', 'same', 'different'] },
 			]);
 
@@ -606,13 +817,13 @@ describe.each<[string, string, StoreFactory]>([
 	describe('within-batch deduplication', () => {
 		it('should deduplicate entities within the same createEntities call', async () => {
 			// Two entities with the same name in one batch — only the first should be created
-			const result = await store.createEntities([
+			const { created } = await store.createEntities([
 				{ name: 'Alice', entityType: 'person', observations: ['first'] },
 				{ name: 'Alice', entityType: 'robot', observations: ['second'] },
 			]);
 
-			expect(result).toHaveLength(1);
-			expect(result[0].entityType).toBe('person');
+			expect(created).toHaveLength(1);
+			expect(created[0].entityType).toBe('person');
 
 			const graph = await store.readGraph();
 			expect(graph.entities).toHaveLength(1);
@@ -1152,11 +1363,11 @@ describe('SqliteStore-specific', () => {
 			await store.createEntities([
 				{ name: 'Alice', entityType: 'person', observations: ['first'] },
 			]);
-			const result = await store.createEntities([
+			const { created } = await store.createEntities([
 				{ name: 'Alice', entityType: 'robot', observations: ['second'] },
 			]);
 
-			expect(result).toHaveLength(0);
+			expect(created).toHaveLength(0);
 			const graph = await store.readGraph();
 			expect(graph.entities).toHaveLength(1);
 			expect(graph.entities[0].entityType).toBe('person');

--- a/docs/superpowers/plans/2026-04-02-project-filtering.md
+++ b/docs/superpowers/plans/2026-04-02-project-filtering.md
@@ -1,0 +1,1190 @@
+# Project Filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add optional project scoping to the knowledge graph so entities can be tagged to projects and queries can filter by project while including globals.
+
+**Architecture:** Add a `project: string | null` field to entities (nullable TEXT column in SQLite, optional JSON field in JSONL). Modified `GraphStore` interface methods accept an optional `projectId` parameter. Project-scoped queries return project matches + globals. New `list_projects` tool returns distinct project names. `createEntities` returns `{ created, skipped }` to report cross-project name collisions.
+
+**Tech Stack:** TypeScript, better-sqlite3, Vitest, Zod, MCP SDK
+
+**Spec:** `docs/superpowers/specs/2026-04-02-project-filtering-design.md`
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|------|--------|---------------|
+| `types.ts` | Modify | Add `project` to `Entity`, add `CreateEntitiesResult`/`SkippedEntity` types, update `GraphStore` interface |
+| `jsonl-store.ts` | Modify | Add project field to load/save/create/search/read/open/list |
+| `sqlite-store.ts` | Modify | Add project column migration, update queries for project filtering, add `listProjects` |
+| `index.ts` | Modify | Add `projectId` to Zod schemas, normalize input, wire up `list_projects` tool, update `create_entities` response |
+| `__tests__/knowledge-graph.test.ts` | Modify | Add parameterized project filtering tests to shared suite |
+
+---
+
+### Task 1: Update types and GraphStore interface
+
+**Files:**
+- Modify: `types.ts:9-85`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test in `__tests__/knowledge-graph.test.ts` inside the shared `describe.each` block that verifies entities have a `project` field:
+
+```typescript
+// Add inside the shared describe.each block, in the createEntities describe:
+it('should set project to null when no projectId provided', async () => {
+  const result = await store.createEntities([
+    { name: 'GlobalEntity', entityType: 'test', observations: ['global obs'] },
+  ]);
+  expect(result.created).toHaveLength(1);
+  expect(result.created[0].project).toBeNull();
+  expect(result.skipped).toHaveLength(0);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test 2>&1 | tail -20`
+Expected: TypeScript compilation errors -- `project` does not exist on `Entity`, `created`/`skipped` do not exist on return type.
+
+- [ ] **Step 3: Update types.ts with new types and interface changes**
+
+In `types.ts`, make these changes:
+
+Add `project` to the `Entity` interface (after `observations`):
+
+```typescript
+export interface Entity {
+  name: string;
+  entityType: string;
+  observations: Observation[];
+  project: string | null;  // null = global, never undefined
+}
+```
+
+Add new types after `AddObservationResult`:
+
+```typescript
+/** An entity that was skipped during createEntities because its name
+ *  already exists (possibly in a different project). */
+export type SkippedEntity = {
+  name: string;
+  existingProject: string | null;
+};
+
+/** Return type for createEntities. Reports both created entities and
+ *  skipped duplicates with their owning project for collision feedback. */
+export type CreateEntitiesResult = {
+  created: Entity[];
+  skipped: SkippedEntity[];
+};
+```
+
+Update `GraphStore` interface -- change `createEntities` return type and add `projectId` parameters plus `listProjects`:
+
+```typescript
+export interface GraphStore {
+  init(): Promise<void>;
+  close(): Promise<void>;
+
+  createEntities(entities: EntityInput[], projectId?: string): Promise<Readonly<CreateEntitiesResult>>;
+  createRelations(relations: Relation[]): Promise<Readonly<Relation[]>>;
+  addObservations(observations: AddObservationInput[]): Promise<Readonly<AddObservationResult[]>>;
+  deleteEntities(entityNames: string[]): Promise<void>;
+  deleteObservations(deletions: DeleteObservationInput[]): Promise<void>;
+  deleteRelations(relations: Relation[]): Promise<void>;
+  readGraph(projectId?: string): Promise<Readonly<KnowledgeGraph>>;
+  searchNodes(query: string, projectId?: string): Promise<Readonly<KnowledgeGraph>>;
+  openNodes(names: string[], projectId?: string): Promise<Readonly<KnowledgeGraph>>;
+  listProjects(): Promise<string[]>;
+}
+```
+
+- [ ] **Step 4: Run build to verify types compile**
+
+Run: `npm run build 2>&1 | head -30`
+Expected: Compilation errors in `jsonl-store.ts` and `sqlite-store.ts` because their implementations don't match the new interface yet. This confirms the interface changes propagate correctly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add types.ts __tests__/knowledge-graph.test.ts
+git commit -m "feat: add project field to Entity type and update GraphStore interface"
+```
+
+---
+
+### Task 2: Implement project filtering in JsonlStore
+
+**Files:**
+- Modify: `jsonl-store.ts:90-337`
+
+- [ ] **Step 1: Write failing tests for project filtering**
+
+Add these tests inside the shared `describe.each` block (they run against both stores). Place them in a new `describe('project filtering', ...)` block after the existing `openNodes` describe:
+
+```typescript
+describe('project filtering', () => {
+  it('should tag entities with projectId on create', async () => {
+    const result = await store.createEntities(
+      [{ name: 'ProjectEntity', entityType: 'test', observations: ['obs1'] }],
+      'my-project'
+    );
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0].project).toBe('my-project');
+    expect(result.skipped).toHaveLength(0);
+  });
+
+  it('should set project to null when projectId omitted', async () => {
+    const result = await store.createEntities([
+      { name: 'GlobalEntity', entityType: 'test', observations: ['obs1'] },
+    ]);
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0].project).toBeNull();
+  });
+
+  it('should normalize projectId to lowercase and trimmed', async () => {
+    const result = await store.createEntities(
+      [{ name: 'NormEntity', entityType: 'test', observations: ['obs1'] }],
+      '  My-Project  '
+    );
+    expect(result.created[0].project).toBe('my-project');
+  });
+
+  it('should report skipped entities with existing project info', async () => {
+    await store.createEntities(
+      [{ name: 'Shared', entityType: 'test', observations: ['obs1'] }],
+      'project-a'
+    );
+    const result = await store.createEntities(
+      [{ name: 'Shared', entityType: 'test', observations: ['obs2'] }],
+      'project-b'
+    );
+    expect(result.created).toHaveLength(0);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]).toEqual({ name: 'Shared', existingProject: 'project-a' });
+  });
+
+  it('should filter readGraph by project + globals', async () => {
+    await store.createEntities(
+      [{ name: 'A', entityType: 'test', observations: ['a'] }],
+      'proj-1'
+    );
+    await store.createEntities(
+      [{ name: 'B', entityType: 'test', observations: ['b'] }],
+      'proj-2'
+    );
+    await store.createEntities([
+      { name: 'G', entityType: 'test', observations: ['global'] },
+    ]);
+
+    const filtered = await store.readGraph('proj-1');
+    const names = filtered.entities.map(e => e.name).sort();
+    expect(names).toEqual(['A', 'G']);
+  });
+
+  it('should return entire graph when readGraph has no projectId', async () => {
+    await store.createEntities(
+      [{ name: 'A', entityType: 'test', observations: ['a'] }],
+      'proj-1'
+    );
+    await store.createEntities(
+      [{ name: 'B', entityType: 'test', observations: ['b'] }],
+      'proj-2'
+    );
+    await store.createEntities([
+      { name: 'G', entityType: 'test', observations: ['global'] },
+    ]);
+
+    const all = await store.readGraph();
+    expect(all.entities).toHaveLength(3);
+  });
+
+  it('should filter searchNodes by project + globals', async () => {
+    await store.createEntities(
+      [{ name: 'Alpha', entityType: 'test', observations: ['shared keyword'] }],
+      'proj-1'
+    );
+    await store.createEntities(
+      [{ name: 'Beta', entityType: 'test', observations: ['shared keyword'] }],
+      'proj-2'
+    );
+    await store.createEntities([
+      { name: 'Gamma', entityType: 'test', observations: ['shared keyword'] },
+    ]);
+
+    const result = await store.searchNodes('shared', 'proj-1');
+    const names = result.entities.map(e => e.name).sort();
+    expect(names).toEqual(['Alpha', 'Gamma']);
+  });
+
+  it('should search entire graph when searchNodes has no projectId', async () => {
+    await store.createEntities(
+      [{ name: 'Alpha', entityType: 'test', observations: ['keyword'] }],
+      'proj-1'
+    );
+    await store.createEntities(
+      [{ name: 'Beta', entityType: 'test', observations: ['keyword'] }],
+      'proj-2'
+    );
+
+    const result = await store.searchNodes('keyword');
+    expect(result.entities).toHaveLength(2);
+  });
+
+  it('should filter openNodes by project + globals', async () => {
+    await store.createEntities(
+      [{ name: 'X', entityType: 'test', observations: ['x'] }],
+      'proj-1'
+    );
+    await store.createEntities(
+      [{ name: 'Y', entityType: 'test', observations: ['y'] }],
+      'proj-2'
+    );
+    await store.createEntities([
+      { name: 'Z', entityType: 'test', observations: ['z'] },
+    ]);
+
+    const result = await store.openNodes(['X', 'Y', 'Z'], 'proj-1');
+    const names = result.entities.map(e => e.name).sort();
+    expect(names).toEqual(['X', 'Z']);
+  });
+
+  it('should return all requested entities when openNodes has no projectId', async () => {
+    await store.createEntities(
+      [{ name: 'X', entityType: 'test', observations: ['x'] }],
+      'proj-1'
+    );
+    await store.createEntities(
+      [{ name: 'Y', entityType: 'test', observations: ['y'] }],
+      'proj-2'
+    );
+
+    const result = await store.openNodes(['X', 'Y']);
+    expect(result.entities).toHaveLength(2);
+  });
+
+  it('should only include relations where both endpoints are in the result set', async () => {
+    await store.createEntities(
+      [{ name: 'P1', entityType: 'test', observations: ['p1'] }],
+      'proj-1'
+    );
+    await store.createEntities(
+      [{ name: 'P2', entityType: 'test', observations: ['p2'] }],
+      'proj-2'
+    );
+    await store.createEntities([
+      { name: 'Global', entityType: 'test', observations: ['g'] },
+    ]);
+    await store.createRelations([
+      { from: 'P1', to: 'Global', relationType: 'uses' },
+      { from: 'P1', to: 'P2', relationType: 'cross_project' },
+      { from: 'P2', to: 'Global', relationType: 'also_uses' },
+    ]);
+
+    const result = await store.readGraph('proj-1');
+    expect(result.entities.map(e => e.name).sort()).toEqual(['Global', 'P1']);
+    // Only P1->Global should be included (both endpoints in result set)
+    // P1->P2 excluded (P2 not in result), P2->Global excluded (P2 not in result)
+    expect(result.relations).toHaveLength(1);
+    expect(result.relations[0]).toEqual(
+      expect.objectContaining({ from: 'P1', to: 'Global', relationType: 'uses' })
+    );
+  });
+
+  it('should list distinct project names sorted alphabetically', async () => {
+    await store.createEntities(
+      [{ name: 'A', entityType: 'test', observations: ['a'] }],
+      'zebra'
+    );
+    await store.createEntities(
+      [{ name: 'B', entityType: 'test', observations: ['b'] }],
+      'alpha'
+    );
+    await store.createEntities([
+      { name: 'C', entityType: 'test', observations: ['c'] },
+    ]);
+
+    const projects = await store.listProjects();
+    expect(projects).toEqual(['alpha', 'zebra']);
+  });
+
+  it('should return empty array from listProjects on empty database', async () => {
+    const projects = await store.listProjects();
+    expect(projects).toEqual([]);
+  });
+
+  it('should persist project field across store restarts', async () => {
+    await store.createEntities(
+      [{ name: 'Persistent', entityType: 'test', observations: ['data'] }],
+      'my-project'
+    );
+
+    await store.close();
+    const store2 = createStore(storePath);
+    await store2.init();
+    const graph = await store2.readGraph();
+    await store2.close();
+
+    store = createStore(storePath);
+    await store.init();
+
+    expect(graph.entities[0].project).toBe('my-project');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test 2>&1 | tail -20`
+Expected: Compilation errors -- `JsonlStore.createEntities` doesn't accept `projectId`, doesn't return `CreateEntitiesResult`, `listProjects` doesn't exist.
+
+- [ ] **Step 3: Implement project filtering in JsonlStore**
+
+**3a. Update imports** -- add `SkippedEntity` and `CreateEntitiesResult` to the imports from `./types.js`:
+
+```typescript
+import {
+  createObservation,
+  type Observation,
+  type Entity,
+  type Relation,
+  type KnowledgeGraph,
+  type GraphStore,
+  type EntityInput,
+  type AddObservationInput,
+  type DeleteObservationInput,
+  type AddObservationResult,
+  type SkippedEntity,
+  type CreateEntitiesResult,
+} from './types.js';
+```
+
+**3b. Update `loadGraph` to parse `project` field** -- in `jsonl-store.ts`, find the entity push block (line ~128) and add `project`:
+
+```typescript
+graph.entities.push({
+  name: item.name,
+  entityType: item.entityType,
+  observations: (item.observations || []).map(normalizeObservation),
+  project: typeof item.project === 'string' ? item.project : null,
+});
+```
+
+**3c. Update `saveGraph` to serialize `project` field** -- in `jsonl-store.ts`, line ~166:
+
+```typescript
+...graph.entities.map(e => JSON.stringify({
+  type: "entity", name: e.name, entityType: e.entityType,
+  observations: e.observations, project: e.project
+})),
+```
+
+**3d. Rewrite `createEntities`** -- replace the existing method (line ~188):
+
+```typescript
+async createEntities(entities: EntityInput[], projectId?: string): Promise<CreateEntitiesResult> {
+  const graph = await this.loadGraph();
+  const normalizedProject = projectId?.trim().toLowerCase() || null;
+
+  const normalized: Entity[] = entities.map(e => ({
+    name: e.name,
+    entityType: e.entityType,
+    observations: [...new Map(
+      e.observations.map(obs => {
+        const o = typeof obs === 'string' ? createObservation(obs) : obs;
+        return [o.content, o] as const;
+      })
+    ).values()],
+    project: normalizedProject,
+  }));
+
+  // Build a map of existing entity names to their project for collision reporting
+  const existingEntityMap = new Map(graph.entities.map(e => [e.name, e.project]));
+  const created: Entity[] = [];
+  const skipped: SkippedEntity[] = [];
+
+  for (const e of normalized) {
+    if (existingEntityMap.has(e.name)) {
+      skipped.push({ name: e.name, existingProject: existingEntityMap.get(e.name)! });
+    } else {
+      existingEntityMap.set(e.name, e.project);
+      created.push(e);
+    }
+  }
+
+  graph.entities.push(...created);
+  await this.saveGraph(graph);
+  return { created, skipped };
+}
+```
+
+**3e. Update `readGraph`** -- replace the existing method (line ~298):
+
+```typescript
+async readGraph(projectId?: string): Promise<KnowledgeGraph> {
+  const graph = await this.loadGraph();
+  if (!projectId) return graph;
+
+  const normalizedProject = projectId.trim().toLowerCase();
+  const filteredEntities = graph.entities.filter(e =>
+    e.project === normalizedProject || e.project === null
+  );
+  const filteredEntityNames = new Set(filteredEntities.map(e => e.name));
+  const filteredRelations = graph.relations.filter(r =>
+    filteredEntityNames.has(r.from) && filteredEntityNames.has(r.to)
+  );
+  return { entities: filteredEntities, relations: filteredRelations };
+}
+```
+
+**3f. Update `searchNodes`** -- replace the existing method (line ~308):
+
+```typescript
+async searchNodes(query: string, projectId?: string): Promise<KnowledgeGraph> {
+  const graph = await this.loadGraph();
+  const lowerQuery = query.toLowerCase();
+  const normalizedProject = projectId?.trim().toLowerCase();
+
+  let filteredEntities = graph.entities.filter(e =>
+    e.name.toLowerCase().includes(lowerQuery) ||
+    e.entityType.toLowerCase().includes(lowerQuery) ||
+    e.observations.some(o => o.content.toLowerCase().includes(lowerQuery))
+  );
+
+  if (normalizedProject) {
+    filteredEntities = filteredEntities.filter(e =>
+      e.project === normalizedProject || e.project === null
+    );
+  }
+
+  const filteredEntityNames = new Set(filteredEntities.map(e => e.name));
+  const filteredRelations = graph.relations.filter(r =>
+    filteredEntityNames.has(r.from) && filteredEntityNames.has(r.to)
+  );
+  return { entities: filteredEntities, relations: filteredRelations };
+}
+```
+
+**3g. Update `openNodes`** -- replace the existing method (line ~327):
+
+```typescript
+async openNodes(names: string[], projectId?: string): Promise<KnowledgeGraph> {
+  const graph = await this.loadGraph();
+  const nameSet = new Set(names);
+  const normalizedProject = projectId?.trim().toLowerCase();
+
+  let filteredEntities = graph.entities.filter(e => nameSet.has(e.name));
+
+  if (normalizedProject) {
+    filteredEntities = filteredEntities.filter(e =>
+      e.project === normalizedProject || e.project === null
+    );
+  }
+
+  const filteredEntityNames = new Set(filteredEntities.map(e => e.name));
+  const filteredRelations = graph.relations.filter(r =>
+    filteredEntityNames.has(r.from) && filteredEntityNames.has(r.to)
+  );
+  return { entities: filteredEntities, relations: filteredRelations };
+}
+```
+
+**3h. Add `listProjects`** -- add after `openNodes`:
+
+```typescript
+async listProjects(): Promise<string[]> {
+  const graph = await this.loadGraph();
+  const projects = new Set<string>();
+  for (const e of graph.entities) {
+    if (e.project !== null) projects.add(e.project);
+  }
+  return [...projects].sort();
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test 2>&1 | tail -30`
+Expected: JsonlStore tests should pass for project filtering. SqliteStore tests will still fail (not yet updated).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add types.ts jsonl-store.ts __tests__/knowledge-graph.test.ts
+git commit -m "feat: add project filtering to JsonlStore with collision reporting"
+```
+
+---
+
+### Task 3: Implement project filtering in SqliteStore
+
+**Files:**
+- Modify: `sqlite-store.ts:64-547`
+
+- [ ] **Step 1: Update imports**
+
+Add `SkippedEntity` and `CreateEntitiesResult` to the imports from `./types.js`:
+
+```typescript
+import {
+  createObservation,
+  type Observation,
+  type Entity,
+  type Relation,
+  type KnowledgeGraph,
+  type GraphStore,
+  type EntityInput,
+  type AddObservationInput,
+  type DeleteObservationInput,
+  type AddObservationResult,
+  type SkippedEntity,
+  type CreateEntitiesResult,
+} from './types.js';
+```
+
+- [ ] **Step 2: Add project column to schema and migration**
+
+Update the `CREATE TABLE entities` statement in `init()` to include `project` for fresh databases:
+
+```sql
+CREATE TABLE IF NOT EXISTS entities (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  name        TEXT NOT NULL UNIQUE,
+  entity_type TEXT NOT NULL,
+  project     TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_entities_project ON entities(project);
+```
+
+After the `CREATE TABLE` block, add the migration check for existing databases:
+
+```typescript
+// Migrate: add project column if upgrading from pre-Phase-3 schema
+const columns = this.db.pragma('table_info(entities)') as { name: string }[];
+const hasProject = columns.some(c => c.name === 'project');
+if (!hasProject) {
+  this.db.exec(`
+    ALTER TABLE entities ADD COLUMN project TEXT;
+    CREATE INDEX IF NOT EXISTS idx_entities_project ON entities(project);
+  `);
+}
+```
+
+- [ ] **Step 3: Update createEntities**
+
+Replace the existing `createEntities` method (line ~227):
+
+```typescript
+async createEntities(entities: EntityInput[], projectId?: string): Promise<CreateEntitiesResult> {
+  const normalizedProject = projectId?.trim().toLowerCase() || null;
+
+  const insertEntity = this.db.prepare(
+    'INSERT OR IGNORE INTO entities (name, entity_type, project) VALUES (?, ?, ?)'
+  );
+  const getEntityId = this.db.prepare(
+    'SELECT id FROM entities WHERE name = ?'
+  );
+  const getEntityProject = this.db.prepare(
+    'SELECT project FROM entities WHERE name = ?'
+  );
+  const insertObs = this.db.prepare(
+    'INSERT OR IGNORE INTO observations (entity_id, content, created_at) VALUES (?, ?, ?)'
+  );
+
+  const created: Entity[] = [];
+  const skipped: SkippedEntity[] = [];
+
+  const txn = this.db.transaction(() => {
+    for (const e of entities) {
+      const info = insertEntity.run(e.name, e.entityType, normalizedProject);
+      if (info.changes === 0) {
+        // Entity already exists -- report which project owns it
+        const existing = getEntityProject.get(e.name) as { project: string | null } | undefined;
+        skipped.push({ name: e.name, existingProject: existing?.project ?? null });
+        continue;
+      }
+
+      const row = getEntityId.get(e.name) as { id: number };
+      const observations: Observation[] = [];
+
+      for (const obs of e.observations) {
+        const o = typeof obs === 'string' ? createObservation(obs) : obs;
+        const obsInfo = insertObs.run(row.id, o.content, o.createdAt);
+        if (obsInfo.changes > 0) {
+          observations.push(o);
+        }
+      }
+
+      created.push({ name: e.name, entityType: e.entityType, observations, project: normalizedProject });
+    }
+  });
+  txn();
+
+  return { created, skipped };
+}
+```
+
+- [ ] **Step 4: Update buildEntities to include project**
+
+In `buildEntities` (line ~407), update the parameter type and return mapping:
+
+```typescript
+private buildEntities(entityRows: { name: string; entityType: string; project: string | null }[]): Entity[] {
+  if (entityRows.length === 0) return [];
+
+  const names = entityRows.map(e => e.name);
+
+  const obsMap = new Map<string, Observation[]>();
+  for (let i = 0; i < names.length; i += CHUNK_SIZE) {
+    const chunk = names.slice(i, i + CHUNK_SIZE);
+    const placeholders = chunk.map(() => '?').join(',');
+
+    const obsRows = this.db.prepare(`
+      SELECT e.name AS entityName, o.content, o.created_at AS createdAt
+      FROM observations o
+      JOIN entities e ON o.entity_id = e.id
+      WHERE e.name IN (${placeholders})
+    `).all(...chunk) as { entityName: string; content: string; createdAt: string }[];
+
+    for (const o of obsRows) {
+      if (!obsMap.has(o.entityName)) obsMap.set(o.entityName, []);
+      obsMap.get(o.entityName)!.push({ content: o.content, createdAt: o.createdAt });
+    }
+  }
+
+  return entityRows.map(e => ({
+    name: e.name,
+    entityType: e.entityType,
+    observations: obsMap.get(e.name) || [],
+    project: e.project,
+  }));
+}
+```
+
+- [ ] **Step 5: Update getConnectedRelations to support both-endpoints mode**
+
+Replace the existing `getConnectedRelations` (line ~447):
+
+```typescript
+private getConnectedRelations(entityNames: string[], bothEndpoints: boolean = false): Relation[] {
+  if (entityNames.length === 0) return [];
+
+  const entityNameSet = bothEndpoints ? new Set(entityNames) : null;
+  const halfChunk = Math.floor(CHUNK_SIZE / 2);
+  const results: Relation[] = [];
+
+  for (let i = 0; i < entityNames.length; i += halfChunk) {
+    const chunk = entityNames.slice(i, i + halfChunk);
+    const placeholders = chunk.map(() => '?').join(',');
+    const rows = this.db.prepare(`
+      SELECT from_entity AS "from", to_entity AS "to", relation_type AS relationType
+      FROM relations
+      WHERE from_entity IN (${placeholders}) OR to_entity IN (${placeholders})
+    `).all(...chunk, ...chunk) as Relation[];
+    results.push(...rows);
+  }
+
+  // Deduplicate cross-chunk results
+  const seen = new Set<string>();
+  const deduped = results.filter(r => {
+    const key = JSON.stringify([r.from, r.to, r.relationType]);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  // If bothEndpoints is true, filter to relations where BOTH endpoints are in the set
+  if (entityNameSet) {
+    return deduped.filter(r => entityNameSet.has(r.from) && entityNameSet.has(r.to));
+  }
+  return deduped;
+}
+```
+
+- [ ] **Step 6: Update readGraph with project filtering**
+
+Replace the existing `readGraph` (line ~481):
+
+```typescript
+async readGraph(projectId?: string): Promise<KnowledgeGraph> {
+  let entityRows: { name: string; entityType: string; project: string | null }[];
+
+  if (projectId) {
+    const normalizedProject = projectId.trim().toLowerCase();
+    entityRows = this.db.prepare(
+      'SELECT name, entity_type AS entityType, project FROM entities WHERE project = ? OR project IS NULL'
+    ).all(normalizedProject) as { name: string; entityType: string; project: string | null }[];
+  } else {
+    entityRows = this.db.prepare(
+      'SELECT name, entity_type AS entityType, project FROM entities'
+    ).all() as { name: string; entityType: string; project: string | null }[];
+  }
+
+  const entities = this.buildEntities(entityRows);
+  const entityNames = entityRows.map(e => e.name);
+
+  let relations: Relation[];
+  if (projectId) {
+    relations = this.getConnectedRelations(entityNames, true);
+  } else {
+    relations = this.db.prepare(
+      'SELECT from_entity AS "from", to_entity AS "to", relation_type AS relationType FROM relations'
+    ).all() as Relation[];
+  }
+
+  return { entities, relations };
+}
+```
+
+- [ ] **Step 7: Update searchNodes with project filtering**
+
+Replace the existing `searchNodes` (line ~505):
+
+```typescript
+async searchNodes(query: string, projectId?: string): Promise<KnowledgeGraph> {
+  const escaped = escapeLike(query);
+  const pattern = `%${escaped}%`;
+  const normalizedProject = projectId?.trim().toLowerCase();
+
+  let entityRows: { name: string; entityType: string; project: string | null }[];
+
+  if (normalizedProject) {
+    entityRows = this.db.prepare(`
+      SELECT DISTINCT e.name, e.entity_type AS entityType, e.project
+      FROM entities e
+      LEFT JOIN observations o ON o.entity_id = e.id
+      WHERE (e.project = ? OR e.project IS NULL)
+        AND (e.name LIKE ? ESCAPE '\\' OR e.entity_type LIKE ? ESCAPE '\\' OR o.content LIKE ? ESCAPE '\\')
+    `).all(normalizedProject, pattern, pattern, pattern) as { name: string; entityType: string; project: string | null }[];
+  } else {
+    entityRows = this.db.prepare(`
+      SELECT DISTINCT e.name, e.entity_type AS entityType, e.project
+      FROM entities e
+      LEFT JOIN observations o ON o.entity_id = e.id
+      WHERE e.name LIKE ? ESCAPE '\\' OR e.entity_type LIKE ? ESCAPE '\\' OR o.content LIKE ? ESCAPE '\\'
+    `).all(pattern, pattern, pattern) as { name: string; entityType: string; project: string | null }[];
+  }
+
+  const entities = this.buildEntities(entityRows);
+  const bothEndpoints = !!normalizedProject;
+  const relations = this.getConnectedRelations(entityRows.map(e => e.name), bothEndpoints);
+
+  return { entities, relations };
+}
+```
+
+- [ ] **Step 8: Update openNodes with project filtering**
+
+Replace the existing `openNodes` (line ~535):
+
+```typescript
+async openNodes(names: string[], projectId?: string): Promise<KnowledgeGraph> {
+  if (names.length === 0) return { entities: [], relations: [] };
+
+  const normalizedProject = projectId?.trim().toLowerCase();
+  const placeholders = names.map(() => '?').join(',');
+
+  let entityRows: { name: string; entityType: string; project: string | null }[];
+
+  if (normalizedProject) {
+    entityRows = this.db.prepare(
+      `SELECT name, entity_type AS entityType, project FROM entities WHERE name IN (${placeholders}) AND (project = ? OR project IS NULL)`
+    ).all(...names, normalizedProject) as { name: string; entityType: string; project: string | null }[];
+  } else {
+    entityRows = this.db.prepare(
+      `SELECT name, entity_type AS entityType, project FROM entities WHERE name IN (${placeholders})`
+    ).all(...names) as { name: string; entityType: string; project: string | null }[];
+  }
+
+  const entities = this.buildEntities(entityRows);
+  const bothEndpoints = !!normalizedProject;
+  const relations = this.getConnectedRelations(entityRows.map(e => e.name), bothEndpoints);
+
+  return { entities, relations };
+}
+```
+
+- [ ] **Step 9: Add listProjects method**
+
+Add after `openNodes`:
+
+```typescript
+async listProjects(): Promise<string[]> {
+  const rows = this.db.prepare(
+    'SELECT DISTINCT project FROM entities WHERE project IS NOT NULL ORDER BY project'
+  ).all() as { project: string }[];
+  return rows.map(r => r.project);
+}
+```
+
+- [ ] **Step 10: Update migrateFromJsonl to copy project field**
+
+In the `migrateFromJsonl` method, update the entity INSERT prepared statement:
+
+```typescript
+const insertEntity = this.db.prepare(
+  'INSERT OR IGNORE INTO entities (name, entity_type, project) VALUES (?, ?, ?)'
+);
+```
+
+And update the insert call:
+
+```typescript
+insertEntity.run(entity.name, entity.entityType, entity.project ?? null);
+```
+
+- [ ] **Step 11: Run all tests**
+
+Run: `npm test 2>&1`
+Expected: All project filtering tests pass for both JsonlStore and SqliteStore. All existing tests pass.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add sqlite-store.ts
+git commit -m "feat: add project filtering to SqliteStore with migration and collision reporting"
+```
+
+---
+
+### Task 4: Fix existing tests for new createEntities return type
+
+**Files:**
+- Modify: `__tests__/knowledge-graph.test.ts`
+
+The existing tests call `store.createEntities()` and expect it to return `Entity[]`. Now it returns `CreateEntitiesResult` (`{ created, skipped }`). All existing tests that check the return value of `createEntities` must be updated.
+
+- [ ] **Step 1: Update all existing createEntities test assertions**
+
+Find every test that assigns the result of `store.createEntities(...)` to a variable and update using destructuring:
+
+**Pattern:** Replace `const newEntities = await store.createEntities(...)` with `const { created: newEntities } = await store.createEntities(...)`
+
+Key tests to update (search for `await store.createEntities` in the test file where the return value is assigned):
+
+- `'should create new entities'` -- destructure to `{ created: newEntities }`
+- `'should not create duplicate entities'` -- destructure to `{ created: newEntities }`
+- `'should handle empty entity arrays'` -- destructure to `{ created: newEntities }`
+- `'should deduplicate entities within the same batch'` -- destructure to `{ created: newEntities }`
+- `'should deduplicate observations within a single entity'` -- destructure to `{ created: newEntities }`
+- Any other test that checks the return value of `createEntities`
+
+Tests that call `store.createEntities(...)` as setup (not checking the return value) don't need changes.
+
+- [ ] **Step 2: Run all tests**
+
+Run: `npm test 2>&1`
+Expected: All tests pass (129+ existing tests plus ~15 new project filtering tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add __tests__/knowledge-graph.test.ts
+git commit -m "fix: update existing tests for new createEntities return type"
+```
+
+---
+
+### Task 5: Add SQLite-specific migration test
+
+**Files:**
+- Modify: `__tests__/knowledge-graph.test.ts`
+
+- [ ] **Step 1: Add migration test in the SQLite-specific section**
+
+Find the `describe('SqliteStore-specific', ...)` section and add:
+
+```typescript
+it('should migrate existing database by adding project column', async () => {
+  // Create a store and add an entity (simulates pre-Phase-3 database)
+  const migrationPath = path.join(testDir, `test-migration-project-${Date.now()}.db`);
+  const store1 = new SqliteStore(migrationPath);
+  await store1.init();
+  await store1.createEntities([
+    { name: 'OldEntity', entityType: 'test', observations: ['old data'] },
+  ]);
+  await store1.close();
+
+  // Re-open -- init() should detect missing project column and add it
+  const store2 = new SqliteStore(migrationPath);
+  await store2.init();
+
+  const graph = await store2.readGraph();
+  expect(graph.entities[0].project).toBeNull();
+
+  // Verify new entities can be created with project
+  await store2.createEntities(
+    [{ name: 'NewEntity', entityType: 'test', observations: ['new data'] }],
+    'test-project'
+  );
+  const graph2 = await store2.readGraph('test-project');
+  const names = graph2.entities.map(e => e.name).sort();
+  expect(names).toEqual(['NewEntity', 'OldEntity']); // OldEntity is global, included
+
+  await store2.close();
+  for (const suffix of ['', '-wal', '-shm']) {
+    try { await fs.unlink(migrationPath + suffix); } catch { /* ignore */ }
+  }
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test 2>&1`
+Expected: All tests pass including the new migration test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add __tests__/knowledge-graph.test.ts
+git commit -m "test: add SQLite migration test for project column"
+```
+
+---
+
+### Task 6: Update MCP tool registrations in index.ts
+
+**Files:**
+- Modify: `index.ts:77-276`
+
+- [ ] **Step 1: Update EntityOutputSchema to include project**
+
+In `index.ts`, update the `EntityOutputSchema` (line ~93):
+
+```typescript
+const EntityOutputSchema = z.object({
+  name: z.string().describe("The name of the entity"),
+  entityType: z.string().describe("The type of the entity"),
+  observations: z.array(ObservationSchema).describe("An array of observations with content and timestamps"),
+  project: z.string().nullable().describe("Project this entity belongs to, or null for global"),
+});
+```
+
+- [ ] **Step 2: Add projectId Zod schema constant and normalizeProjectId helper**
+
+After `RelationSchema` (line ~103), add:
+
+```typescript
+const ProjectIdSchema = z.string().min(1).max(500)
+  .describe("Project scope for filtering. Omit for global/unscoped.")
+  .optional();
+
+/**
+ * Normalizes a projectId input: trims whitespace, lowercases, and converts
+ * empty/undefined to undefined (so the store treats it as global).
+ * Called in tool handlers before passing to store methods.
+ */
+function normalizeProjectId(projectId?: string): string | undefined {
+  if (!projectId) return undefined;
+  const normalized = projectId.trim().toLowerCase();
+  return normalized || undefined;
+}
+```
+
+- [ ] **Step 3: Add SkippedEntity output schema**
+
+After `ProjectIdSchema`, add:
+
+```typescript
+const SkippedEntitySchema = z.object({
+  name: z.string(),
+  existingProject: z.string().nullable(),
+});
+```
+
+- [ ] **Step 4: Update create_entities tool**
+
+Replace the `create_entities` tool registration (line ~110):
+
+```typescript
+server.registerTool(
+  "create_entities",
+  {
+    title: "Create Entities",
+    description: "Create multiple new entities in the knowledge graph",
+    inputSchema: {
+      entities: z.array(EntityInputSchema).max(100),
+      projectId: ProjectIdSchema,
+    },
+    outputSchema: {
+      created: z.array(EntityOutputSchema),
+      skipped: z.array(SkippedEntitySchema),
+    }
+  },
+  async ({ entities, projectId }) => {
+    const result = await store.createEntities(entities, normalizeProjectId(projectId));
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+      structuredContent: { created: result.created, skipped: result.skipped }
+    };
+  }
+);
+```
+
+- [ ] **Step 5: Update read_graph tool**
+
+Replace the `read_graph` tool registration (line ~227):
+
+```typescript
+server.registerTool(
+  "read_graph",
+  {
+    title: "Read Graph",
+    description: "Read the entire knowledge graph",
+    inputSchema: { projectId: ProjectIdSchema },
+    outputSchema: { entities: z.array(EntityOutputSchema), relations: z.array(RelationSchema) }
+  },
+  async ({ projectId }) => {
+    const graph = await store.readGraph(normalizeProjectId(projectId));
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(graph, null, 2) }],
+      structuredContent: { ...graph }
+    };
+  }
+);
+```
+
+- [ ] **Step 6: Update search_nodes tool**
+
+Replace the `search_nodes` tool registration (line ~244):
+
+```typescript
+server.registerTool(
+  "search_nodes",
+  {
+    title: "Search Nodes",
+    description: "Search for nodes in the knowledge graph based on a query",
+    inputSchema: {
+      query: z.string().min(1).max(5000).describe("The search query to match against entity names, types, and observation content"),
+      projectId: ProjectIdSchema,
+    },
+    outputSchema: { entities: z.array(EntityOutputSchema), relations: z.array(RelationSchema) }
+  },
+  async ({ query, projectId }) => {
+    const graph = await store.searchNodes(query, normalizeProjectId(projectId));
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(graph, null, 2) }],
+      structuredContent: { ...graph }
+    };
+  }
+);
+```
+
+- [ ] **Step 7: Update open_nodes tool**
+
+Replace the `open_nodes` tool registration (line ~261):
+
+```typescript
+server.registerTool(
+  "open_nodes",
+  {
+    title: "Open Nodes",
+    description: "Open specific nodes in the knowledge graph by their names",
+    inputSchema: {
+      names: z.array(z.string().min(1).max(500)).max(100).describe("An array of entity names to retrieve"),
+      projectId: ProjectIdSchema,
+    },
+    outputSchema: { entities: z.array(EntityOutputSchema), relations: z.array(RelationSchema) }
+  },
+  async ({ names, projectId }) => {
+    const graph = await store.openNodes(names, normalizeProjectId(projectId));
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(graph, null, 2) }],
+      structuredContent: { ...graph }
+    };
+  }
+);
+```
+
+- [ ] **Step 8: Add list_projects tool**
+
+After the `open_nodes` registration, add:
+
+```typescript
+server.registerTool(
+  "list_projects",
+  {
+    title: "List Projects",
+    description: "List all project names in the knowledge graph",
+    inputSchema: {},
+    outputSchema: { projects: z.array(z.string()) }
+  },
+  async () => {
+    const projects = await store.listProjects();
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(projects, null, 2) }],
+      structuredContent: { projects }
+    };
+  }
+);
+```
+
+- [ ] **Step 9: Update re-exports**
+
+Update the re-exports (line ~70) to include the new types:
+
+```typescript
+export { type Observation, type Entity, type Relation, type KnowledgeGraph, type CreateEntitiesResult, type SkippedEntity } from './types.js';
+```
+
+- [ ] **Step 10: Bump version**
+
+Update the server version (line ~107):
+
+```typescript
+const server = new McpServer({
+  name: "memory-server",
+  version: "0.9.0",
+});
+```
+
+- [ ] **Step 11: Build and test**
+
+Run: `npm run build && npm test 2>&1`
+Expected: Build succeeds, all tests pass.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add index.ts
+git commit -m "feat: add projectId to MCP tools and register list_projects tool"
+```
+
+---
+
+### Task 7: Update CLAUDE.md and bump package version
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `package.json`
+
+- [ ] **Step 1: Update CLAUDE.md architecture section**
+
+Update the architecture section to document project filtering. Key additions:
+
+- Under `types.ts`: mention `project: string | null` on Entity, `CreateEntitiesResult`, `SkippedEntity` types
+- Under `index.ts`: mention `projectId` parameter on tools, `normalizeProjectId()` helper, `list_projects` tool
+- Under `sqlite-store.ts`: mention `project TEXT` column, migration via `table_info` pragma, `idx_entities_project` index
+- Under `jsonl-store.ts`: mention optional `project` field on entity lines
+- Under Known Limitations: add that entity names are globally unique across projects (permanent constraint due to relation FK design)
+- Update Planned Phases: mark Phase 3 as DONE, keep Phase 4
+
+- [ ] **Step 2: Bump package.json version**
+
+Update `version` in `package.json` from `"0.8.0"` to `"0.9.0"`.
+
+- [ ] **Step 3: Run build and tests one final time**
+
+Run: `npm run build && npm test 2>&1`
+Expected: All tests pass, build clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md package.json
+git commit -m "docs: update CLAUDE.md for Phase 3, bump version to 0.9.0"
+```

--- a/docs/superpowers/specs/2026-04-02-project-filtering-design.md
+++ b/docs/superpowers/specs/2026-04-02-project-filtering-design.md
@@ -1,0 +1,260 @@
+# Phase 3: Project Filtering — Design Spec
+
+## Goal
+
+Scope entities to projects so multi-project memory stays clean, while preserving cross-project and global (unscoped) access.
+
+## Core Decisions
+
+- **Approach:** Optional `projectId` parameter on existing tools (Approach A from brainstorming)
+- **Cardinality:** Each entity belongs to exactly one project, or is global (null). No multi-tagging.
+- **Query behavior:** Project-scoped queries return project matches + globals. Unscoped queries return everything.
+- **Naming:** Server-side normalization (lowercase, trim). Client-side CLAUDE.md conventions. `list_projects` tool for discovery.
+- **Migration:** Additive. All existing entities become global (null). Zero breaking changes.
+
+---
+
+## Data Model
+
+### SQLite
+
+Add a nullable `project` column to the `entities` table:
+
+```sql
+ALTER TABLE entities ADD COLUMN project TEXT;
+CREATE INDEX IF NOT EXISTS idx_entities_project ON entities(project);
+```
+
+All existing rows get `NULL` (global). New entities are tagged with the client-provided `projectId` or `NULL` if omitted.
+
+No changes to `observations` or `relations` tables. Observations inherit project scope through their `entity_id` FK to `entities`. Relations inherit scope through their `from_entity`/`to_entity` FKs to `entities.name`.
+
+No separate `projects` table. Project identity is the normalized name string stored directly on `entities.project`. `list_projects` is `SELECT DISTINCT project FROM entities WHERE project IS NOT NULL`.
+
+### JSONL
+
+Each entity line gains an optional `"project"` field:
+
+```json
+{"type":"entity","name":"Foo","entityType":"bar","observations":[...],"project":"mcp-memory-server"}
+```
+
+Omitted or `null` means global. Parsed on load, written on save. No migration needed — existing lines without the field are global by default.
+
+### Normalization
+
+Project names are normalized before reaching the store:
+
+- `trim()` — strip leading/trailing whitespace
+- `toLowerCase()` — case-insensitive matching
+
+Applied in the MCP tool handlers (index.ts), so both backends receive clean input. Empty string after trim is treated as `null` (global).
+
+---
+
+## GraphStore Interface Changes
+
+### Modified Methods
+
+```typescript
+createEntities(entities: EntityInput[], projectId?: string): Promise<Readonly<Entity[]>>;
+readGraph(projectId?: string): Promise<Readonly<KnowledgeGraph>>;
+searchNodes(query: string, projectId?: string): Promise<Readonly<KnowledgeGraph>>;
+openNodes(names: string[], projectId?: string): Promise<Readonly<KnowledgeGraph>>;
+```
+
+### New Method
+
+```typescript
+listProjects(): Promise<string[]>;
+```
+
+Returns distinct non-null project names currently in the database, sorted alphabetically.
+
+### Unchanged Methods
+
+These operate by exact entity name (globally unique) and don't need project scoping:
+
+- `createRelations(relations)` — relations connect named entities; project affinity is inherited
+- `addObservations(observations)` — targets entities by name
+- `deleteEntities(entityNames)` — deletes by name
+- `deleteObservations(deletions)` — targets entities by name
+- `deleteRelations(relations)` — deletes by exact match on all three fields
+
+---
+
+## Query Semantics
+
+### With `projectId` provided
+
+| Operation | Behavior |
+|-----------|----------|
+| `create_entities` | New entities tagged with this project |
+| `read_graph` | Returns entities where `project = :id OR project IS NULL`, plus relations with at least one endpoint in that set |
+| `search_nodes` | Filters search results to entities in this project + globals, plus connected relations |
+| `open_nodes` | Returns requested entities only if they belong to this project or are global, plus connected relations |
+
+### Without `projectId` (omitted or null)
+
+| Operation | Behavior |
+|-----------|----------|
+| `create_entities` | New entities are global (`project = NULL`) |
+| `read_graph` | Returns the entire graph (all projects + globals) |
+| `search_nodes` | Searches the entire graph |
+| `open_nodes` | Returns all requested entities regardless of project |
+
+This is identical to current behavior — full backward compatibility.
+
+---
+
+## MCP Tool Schema Changes
+
+### Modified tools
+
+Each gains an optional `projectId` parameter:
+
+```typescript
+projectId: z.string().min(1).max(500)
+  .describe("Project scope for filtering. Omit for global/unscoped.")
+  .optional()
+```
+
+Tools modified: `create_entities`, `read_graph`, `search_nodes`, `open_nodes`.
+
+### New tool: list_projects
+
+```typescript
+server.registerTool("list_projects", {
+  title: "List Projects",
+  description: "List all project names in the knowledge graph",
+  inputSchema: {},
+  outputSchema: { projects: z.array(z.string()) }
+}, async () => { ... });
+```
+
+### Entity output schema
+
+Add `project` to the entity output schema:
+
+```typescript
+const EntityOutputSchema = z.object({
+  name: z.string(),
+  entityType: z.string(),
+  observations: z.array(ObservationSchema),
+  project: z.string().nullable().describe("Project this entity belongs to, or null for global"),
+});
+```
+
+---
+
+## Migration
+
+### SQLite
+
+On `init()`, detect whether the `project` column exists:
+
+```typescript
+const columns = this.db.pragma('table_info(entities)') as { name: string }[];
+const hasProject = columns.some(c => c.name === 'project');
+if (!hasProject) {
+  this.db.exec(`
+    ALTER TABLE entities ADD COLUMN project TEXT;
+    CREATE INDEX IF NOT EXISTS idx_entities_project ON entities(project);
+  `);
+}
+```
+
+All existing rows get `NULL` (global). No data transformation.
+
+### JSONL
+
+No migration step. Missing `"project"` field is treated as `null` on load.
+
+### JSONL-to-SQLite auto-migration
+
+The existing `migrateFromJsonl()` in `SqliteStore` copies entities from JSONL into SQLite. It must also copy the `project` field if present on the JSONL entity.
+
+---
+
+## CLAUDE.md Conventions
+
+Applied after Phase 3 implementation is complete and tools accept `projectId`.
+
+### ~/Claude/CLAUDE.md (global)
+
+```markdown
+## Memory Server Project Naming
+When using the memory MCP server's project-scoped tools, always pass the
+project directory name (the folder under ~/Claude/) as the projectId,
+lowercased. Example: working in ~/Claude/mcp-memory-server/ -> projectId
+"mcp-memory-server". If unsure, call list_projects first to see existing
+project names. Omit projectId for memories that aren't project-specific
+(user preferences, system setup, workflow rules).
+```
+
+### Per-project CLAUDE.md
+
+Each project adds:
+
+```markdown
+## Project Name
+projectId for memory server: `<project-directory-name>`
+```
+
+---
+
+## Entity Type Changes
+
+The `Entity` interface gains an optional `project` field:
+
+```typescript
+export interface Entity {
+  name: string;
+  entityType: string;
+  observations: Observation[];
+  project?: string | null;  // null or undefined = global
+}
+```
+
+`EntityInput` does NOT gain a project field. The `projectId` is passed as a separate parameter to `createEntities()`, not per-entity. This keeps the API clean — all entities in a single `create_entities` call share the same project scope. The `Entity` output type has `project` because it reflects what's stored.
+
+---
+
+## Test Plan
+
+New test cases added to the existing parameterized suite (`describe.each` across both stores):
+
+- Create entities with projectId, verify project is stored
+- Create entities without projectId, verify project is null
+- `search_nodes` with projectId returns project matches + globals, not other projects
+- `search_nodes` without projectId returns everything
+- `read_graph` with projectId returns project entities + globals
+- `read_graph` without projectId returns everything
+- `open_nodes` with projectId returns only matching/global entities
+- `open_nodes` without projectId returns all requested entities
+- `list_projects` returns distinct project names, sorted, excludes null
+- `list_projects` on empty database returns empty array
+- Normalization: uppercase/whitespace projectId is lowercased/trimmed
+- Empty string projectId after trim is treated as global (null)
+- Relations are included when at least one endpoint is in the filtered entity set
+- Existing tests pass unchanged (backward compatibility)
+
+SQLite-specific:
+- Migration adds `project` column to existing database
+- Index `idx_entities_project` is created
+
+---
+
+## Known Limitations
+
+- Entity names remain globally unique across all projects. Two projects cannot have entities with the same name. This is consistent with the existing UNIQUE constraint and avoids ambiguity in relation endpoints.
+- No tool for changing an entity's project after creation. If needed, delete and recreate. This avoids partial-update complexity.
+- JSONL backend: no index on project — filtering is a linear scan (consistent with all other JSONL operations).
+
+---
+
+## Out of Scope
+
+- **Pagination** — Phase 4, designed independently
+- **Per-entity projectId in create_entities** — all entities in a batch share the same projectId. Per-entity scoping adds complexity with no clear use case.
+- **Project metadata** — no descriptions, owners, or timestamps on projects themselves. Projects are just name strings.

--- a/docs/superpowers/specs/2026-04-02-project-filtering-design.md
+++ b/docs/superpowers/specs/2026-04-02-project-filtering-design.md
@@ -48,7 +48,7 @@ Project names are normalized before reaching the store:
 - `trim()` — strip leading/trailing whitespace
 - `toLowerCase()` — case-insensitive matching
 
-Applied in the MCP tool handlers (index.ts), so both backends receive clean input. Empty string after trim is treated as `null` (global).
+Applied in the MCP tool handlers (index.ts), so both backends receive clean input. The Zod schema enforces `.min(1)`, so empty strings are rejected at the validation layer before reaching the handler.
 
 ---
 
@@ -57,10 +57,17 @@ Applied in the MCP tool handlers (index.ts), so both backends receive clean inpu
 ### Modified Methods
 
 ```typescript
-createEntities(entities: EntityInput[], projectId?: string): Promise<Readonly<Entity[]>>;
+createEntities(entities: EntityInput[], projectId?: string): Promise<Readonly<CreateEntitiesResult>>;
 readGraph(projectId?: string): Promise<Readonly<KnowledgeGraph>>;
 searchNodes(query: string, projectId?: string): Promise<Readonly<KnowledgeGraph>>;
 openNodes(names: string[], projectId?: string): Promise<Readonly<KnowledgeGraph>>;
+```
+
+Where `CreateEntitiesResult` is:
+
+```typescript
+type SkippedEntity = { name: string; existingProject: string | null };
+type CreateEntitiesResult = { created: Entity[]; skipped: SkippedEntity[] };
 ```
 
 ### New Method
@@ -90,9 +97,9 @@ These operate by exact entity name (globally unique) and don't need project scop
 | Operation | Behavior |
 |-----------|----------|
 | `create_entities` | New entities tagged with this project |
-| `read_graph` | Returns entities where `project = :id OR project IS NULL`, plus relations with at least one endpoint in that set |
-| `search_nodes` | Filters search results to entities in this project + globals, plus connected relations |
-| `open_nodes` | Returns requested entities only if they belong to this project or are global, plus connected relations |
+| `read_graph` | Returns entities where `project = :id OR project IS NULL`, plus relations where **both** endpoints are in that set |
+| `search_nodes` | Filters search results to entities in this project + globals, plus relations where **both** endpoints are in the result set |
+| `open_nodes` | Returns requested entities only if they belong to this project or are global, plus relations where **both** endpoints are in the result set |
 
 ### Without `projectId` (omitted or null)
 
@@ -190,6 +197,12 @@ lowercased. Example: working in ~/Claude/mcp-memory-server/ -> projectId
 "mcp-memory-server". If unsure, call list_projects first to see existing
 project names. Omit projectId for memories that aren't project-specific
 (user preferences, system setup, workflow rules).
+
+Entity names are globally unique across all projects. Use descriptive,
+project-specific names to avoid collisions. Prefer "PostgreSQL config for
+webapp" over generic names like "Database" or "Config". If create_entities
+reports a skipped entity due to a name collision, create a new entity with
+a more specific name.
 ```
 
 ### Per-project CLAUDE.md
@@ -205,16 +218,18 @@ projectId for memory server: `<project-directory-name>`
 
 ## Entity Type Changes
 
-The `Entity` interface gains an optional `project` field:
+The `Entity` interface gains a required `project` field:
 
 ```typescript
 export interface Entity {
   name: string;
   entityType: string;
   observations: Observation[];
-  project?: string | null;  // null or undefined = global
+  project: string | null;  // null = global, never undefined
 }
 ```
+
+The field is **not optional** — stores must always set it explicitly to either a project name string or `null`. This ensures consistent wire format: `JSON.stringify` always includes `"project": null` or `"project": "name"`, never omitting the field. The Zod output schema `z.string().nullable()` matches this exactly.
 
 `EntityInput` does NOT gain a project field. The `projectId` is passed as a separate parameter to `createEntities()`, not per-entity. This keeps the API clean — all entities in a single `create_entities` call share the same project scope. The `Entity` output type has `project` because it reflects what's stored.
 
@@ -235,8 +250,9 @@ New test cases added to the existing parameterized suite (`describe.each` across
 - `list_projects` returns distinct project names, sorted, excludes null
 - `list_projects` on empty database returns empty array
 - Normalization: uppercase/whitespace projectId is lowercased/trimmed
-- Empty string projectId after trim is treated as global (null)
-- Relations are included when at least one endpoint is in the filtered entity set
+- Relations are included only when both endpoints are in the filtered entity set
+- Cross-project relations are excluded from project-scoped queries (no dangling edges)
+- `createEntities` with cross-project name collision returns skipped array with existing project info
 - Existing tests pass unchanged (backward compatibility)
 
 SQLite-specific:
@@ -245,9 +261,30 @@ SQLite-specific:
 
 ---
 
+## Collision Handling
+
+Entity names are globally unique across all projects. This is a **permanent architectural constraint** — relations use entity names as foreign keys, so relaxing this would require changing the relation schema.
+
+When `createEntities` is called with a `projectId` and an entity name already exists in a **different** project, the entity is skipped (not created). To help the caller understand why, `createEntities` returns a `skipped` array alongside the created entities:
+
+```typescript
+// Return type for createEntities
+{
+  created: Entity[];           // entities that were actually created
+  skipped: SkippedEntity[];    // entities that were skipped due to name collision
+}
+
+type SkippedEntity = {
+  name: string;                // the entity name that collided
+  existingProject: string | null;  // which project owns the existing entity
+};
+```
+
+This gives the LLM enough information to create a differently-named entity instead of silently losing data. When there are no collisions, `skipped` is an empty array.
+
 ## Known Limitations
 
-- Entity names remain globally unique across all projects. Two projects cannot have entities with the same name. This is consistent with the existing UNIQUE constraint and avoids ambiguity in relation endpoints.
+- Entity names are globally unique — two projects cannot have entities with the same name. See "Collision Handling" above.
 - No tool for changing an entity's project after creation. If needed, delete and recreate. This avoids partial-update complexity.
 - JSONL backend: no index on project — filtering is a linear scan (consistent with all other JSONL operations).
 

--- a/index.ts
+++ b/index.ts
@@ -104,7 +104,9 @@ const RelationSchema = z.object({
 });
 
 // Optional project scope for filtering tools. Omit to operate globally.
-const ProjectIdSchema = z.string().min(1).max(500)
+// .trim() strips whitespace BEFORE .min(1) checks length, so whitespace-only
+// inputs like " " or "\t" are rejected instead of silently becoming global scope.
+const ProjectIdSchema = z.string().trim().min(1).max(500)
   .describe("Project scope for filtering. Omit for global/unscoped.")
   .optional();
 
@@ -119,8 +121,11 @@ const ProjectIdSchema = z.string().min(1).max(500)
 function normalizeProjectId(projectId?: string): string | undefined {
   if (!projectId) return undefined;
   // trim() removes surrounding whitespace; toLowerCase() ensures
-  // "MyProject" and "myproject" map to the same scope
-  const normalized = projectId.trim().toLowerCase();
+  // "MyProject" and "myproject" map to the same scope;
+  // normalize('NFC') collapses Unicode equivalents (e.g., NFD "cafe\u0301"
+  // and NFC "caf\u00e9" both become "café") so macOS (NFD) and Linux (NFC)
+  // path-derived project names map to the same scope.
+  const normalized = projectId.trim().toLowerCase().normalize('NFC');
   return normalized || undefined;
 }
 

--- a/index.ts
+++ b/index.ts
@@ -67,7 +67,7 @@ export async function ensureMemoryFilePath(): Promise<StoreConfig> {
 }
 
 // Re-export types that tests and external consumers may need
-export { type Observation, type Entity, type Relation, type KnowledgeGraph } from './types.js';
+export { type Observation, type Entity, type Relation, type KnowledgeGraph, type CreateEntitiesResult, type SkippedEntity } from './types.js';
 export { JsonlStore, normalizeObservation } from './jsonl-store.js';
 export { SqliteStore } from './sqlite-store.js';
 
@@ -94,6 +94,7 @@ const EntityOutputSchema = z.object({
   name: z.string().describe("The name of the entity"),
   entityType: z.string().describe("The type of the entity"),
   observations: z.array(ObservationSchema).describe("An array of observations with content and timestamps"),
+  project: z.string().nullable().describe("Project this entity belongs to, or null for global"),
 });
 
 const RelationSchema = z.object({
@@ -102,9 +103,36 @@ const RelationSchema = z.object({
   relationType: z.string().min(1).max(500).describe("The type of the relation")
 });
 
+// Optional project scope for filtering tools. Omit to operate globally.
+const ProjectIdSchema = z.string().min(1).max(500)
+  .describe("Project scope for filtering. Omit for global/unscoped.")
+  .optional();
+
+/**
+ * Normalizes a projectId input: trims whitespace, lowercases, and converts
+ * empty/undefined to undefined (so the store treats it as global).
+ * Called in tool handlers before passing to store methods.
+ *
+ * @param projectId - Raw projectId string from tool input, may be undefined
+ * @returns Cleaned lowercase string, or undefined if input was empty/missing
+ */
+function normalizeProjectId(projectId?: string): string | undefined {
+  if (!projectId) return undefined;
+  // trim() removes surrounding whitespace; toLowerCase() ensures
+  // "MyProject" and "myproject" map to the same scope
+  const normalized = projectId.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+// Schema for entities that were skipped during create_entities (name collision)
+const SkippedEntitySchema = z.object({
+  name: z.string(),
+  existingProject: z.string().nullable(),
+});
+
 const server = new McpServer({
   name: "memory-server",
-  version: "0.8.0",
+  version: "0.9.0",
 });
 
 server.registerTool(
@@ -112,14 +140,21 @@ server.registerTool(
   {
     title: "Create Entities",
     description: "Create multiple new entities in the knowledge graph",
-    inputSchema: { entities: z.array(EntityInputSchema).max(100) },
-    outputSchema: { entities: z.array(EntityOutputSchema) }
+    inputSchema: {
+      entities: z.array(EntityInputSchema).max(100),
+      projectId: ProjectIdSchema,
+    },
+    outputSchema: {
+      created: z.array(EntityOutputSchema),
+      skipped: z.array(SkippedEntitySchema),
+    }
   },
-  async ({ entities }) => {
-    const result = await store.createEntities(entities);
+  async ({ entities, projectId }) => {
+    // normalizeProjectId lowercases and trims; undefined = global scope
+    const result = await store.createEntities(entities, normalizeProjectId(projectId));
     return {
       content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-      structuredContent: { entities: result }
+      structuredContent: { created: result.created, skipped: result.skipped }
     };
   }
 );
@@ -229,11 +264,11 @@ server.registerTool(
   {
     title: "Read Graph",
     description: "Read the entire knowledge graph",
-    inputSchema: {},
+    inputSchema: { projectId: ProjectIdSchema },
     outputSchema: { entities: z.array(EntityOutputSchema), relations: z.array(RelationSchema) }
   },
-  async () => {
-    const graph = await store.readGraph();
+  async ({ projectId }) => {
+    const graph = await store.readGraph(normalizeProjectId(projectId));
     return {
       content: [{ type: "text" as const, text: JSON.stringify(graph, null, 2) }],
       structuredContent: { ...graph }
@@ -246,11 +281,14 @@ server.registerTool(
   {
     title: "Search Nodes",
     description: "Search for nodes in the knowledge graph based on a query",
-    inputSchema: { query: z.string().min(1).max(5000).describe("The search query to match against entity names, types, and observation content") },
+    inputSchema: {
+      query: z.string().min(1).max(5000).describe("The search query to match against entity names, types, and observation content"),
+      projectId: ProjectIdSchema,
+    },
     outputSchema: { entities: z.array(EntityOutputSchema), relations: z.array(RelationSchema) }
   },
-  async ({ query }) => {
-    const graph = await store.searchNodes(query);
+  async ({ query, projectId }) => {
+    const graph = await store.searchNodes(query, normalizeProjectId(projectId));
     return {
       content: [{ type: "text" as const, text: JSON.stringify(graph, null, 2) }],
       structuredContent: { ...graph }
@@ -263,14 +301,35 @@ server.registerTool(
   {
     title: "Open Nodes",
     description: "Open specific nodes in the knowledge graph by their names",
-    inputSchema: { names: z.array(z.string().min(1).max(500)).max(100).describe("An array of entity names to retrieve") },
+    inputSchema: {
+      names: z.array(z.string().min(1).max(500)).max(100).describe("An array of entity names to retrieve"),
+      projectId: ProjectIdSchema,
+    },
     outputSchema: { entities: z.array(EntityOutputSchema), relations: z.array(RelationSchema) }
   },
-  async ({ names }) => {
-    const graph = await store.openNodes(names);
+  async ({ names, projectId }) => {
+    const graph = await store.openNodes(names, normalizeProjectId(projectId));
     return {
       content: [{ type: "text" as const, text: JSON.stringify(graph, null, 2) }],
       structuredContent: { ...graph }
+    };
+  }
+);
+
+server.registerTool(
+  "list_projects",
+  {
+    title: "List Projects",
+    description: "List all project names in the knowledge graph",
+    inputSchema: {},
+    outputSchema: { projects: z.array(z.string()) }
+  },
+  async () => {
+    // Returns all distinct non-null project names from the store
+    const projects = await store.listProjects();
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(projects, null, 2) }],
+      structuredContent: { projects }
     };
   }
 );

--- a/jsonl-store.ts
+++ b/jsonl-store.ts
@@ -15,6 +15,8 @@ import {
   type AddObservationInput,
   type DeleteObservationInput,
   type AddObservationResult,
+  type SkippedEntity,
+  type CreateEntitiesResult,
 } from './types.js';
 
 /**
@@ -128,7 +130,8 @@ export class JsonlStore implements GraphStore {
             graph.entities.push({
               name: item.name,
               entityType: item.entityType,
-              observations: (item.observations || []).map(normalizeObservation)
+              observations: (item.observations || []).map(normalizeObservation),
+              project: typeof item.project === 'string' ? item.project : null,
             });
           } else if (item.type === "relation") {
             // Validate required fields exist and are strings before pushing
@@ -164,7 +167,8 @@ export class JsonlStore implements GraphStore {
   private async saveGraph(graph: KnowledgeGraph): Promise<void> {
     const lines = [
       ...graph.entities.map(e => JSON.stringify({
-        type: "entity", name: e.name, entityType: e.entityType, observations: e.observations
+        type: "entity", name: e.name, entityType: e.entityType,
+        observations: e.observations, project: e.project
       })),
       ...graph.relations.map(r => JSON.stringify({
         type: "relation", from: r.from, to: r.to, relationType: r.relationType
@@ -181,12 +185,21 @@ export class JsonlStore implements GraphStore {
   }
 
   /**
-   * Creates new entities. Skips name-duplicates (both existing and within-batch).
+   * Creates new entities, optionally scoped to a project.
+   * Skips name-duplicates (both existing and within-batch) and reports which
+   * entities were skipped along with the project that owns the existing entity.
    * Observations can be strings (auto-timestamped) or Observation objects.
    * Duplicate observations within a single entity are deduplicated by content.
+   *
+   * @param entities - Array of EntityInput to create
+   * @param projectId - Optional project name; normalized to lowercase/trimmed. Omit for global.
+   * @returns CreateEntitiesResult with created entities and skipped duplicates
    */
-  async createEntities(entities: EntityInput[]): Promise<Entity[]> {
+  async createEntities(entities: EntityInput[], projectId?: string): Promise<CreateEntitiesResult> {
     const graph = await this.loadGraph();
+    // Normalize the project ID: trim whitespace, lowercase, or null for global
+    const normalizedProject = projectId?.trim().toLowerCase() || null;
+
     const normalized: Entity[] = entities.map(e => ({
       name: e.name,
       entityType: e.entityType,
@@ -196,18 +209,25 @@ export class JsonlStore implements GraphStore {
           return [o.content, o] as const;
         })
       ).values()],
+      project: normalizedProject,
     }));
-    const existingNames = new Set(graph.entities.map(e => e.name));
-    const newEntities: Entity[] = [];
+
+    // Map of entity name → owning project, used for both dedup and skip reporting
+    const existingEntityMap = new Map(graph.entities.map(e => [e.name, e.project]));
+    const created: Entity[] = [];
+    const skipped: SkippedEntity[] = [];
+
     for (const e of normalized) {
-      if (!existingNames.has(e.name)) {
-        existingNames.add(e.name);
-        newEntities.push(e);
+      if (existingEntityMap.has(e.name)) {
+        skipped.push({ name: e.name, existingProject: existingEntityMap.get(e.name)! });
+      } else {
+        existingEntityMap.set(e.name, e.project);
+        created.push(e);
       }
     }
-    graph.entities.push(...newEntities);
+    graph.entities.push(...created);
     await this.saveGraph(graph);
-    return newEntities;
+    return { created, skipped };
   }
 
   /**
@@ -295,43 +315,120 @@ export class JsonlStore implements GraphStore {
     await this.saveGraph(graph);
   }
 
-  /** Returns the entire knowledge graph. */
-  async readGraph(): Promise<KnowledgeGraph> {
-    return this.loadGraph();
+  /**
+   * Returns the knowledge graph, optionally filtered by project.
+   * When projectId is provided, returns entities belonging to that project
+   * plus global entities (project === null). Relations are included only
+   * when both endpoints are in the filtered entity set.
+   * When projectId is omitted, returns the entire unfiltered graph.
+   *
+   * @param projectId - Optional project name to filter by; normalized to lowercase/trimmed
+   * @returns KnowledgeGraph with entities and relations
+   */
+  async readGraph(projectId?: string): Promise<KnowledgeGraph> {
+    const graph = await this.loadGraph();
+    if (!projectId) return graph;
+
+    const normalizedProject = projectId.trim().toLowerCase();
+    const filteredEntities = graph.entities.filter(e =>
+      e.project === normalizedProject || e.project === null
+    );
+    const filteredEntityNames = new Set(filteredEntities.map(e => e.name));
+    const filteredRelations = graph.relations.filter(r =>
+      filteredEntityNames.has(r.from) && filteredEntityNames.has(r.to)
+    );
+    return { entities: filteredEntities, relations: filteredRelations };
   }
 
   /**
    * Searches for entities matching the query (case-insensitive substring match
-   * against name, entityType, or observation content). Returns matching entities
-   * plus relations where at least one endpoint is in the matched set.
+   * against name, entityType, or observation content). Optionally filters by project
+   * (matching entities must belong to the project or be global).
+   * Returns matching entities plus relations where both endpoints are in the result set.
+   *
+   * @param query - Case-insensitive substring to search for
+   * @param projectId - Optional project name; only returns entities in this project or global
+   * @returns KnowledgeGraph with matching entities and connected relations
    */
-  async searchNodes(query: string): Promise<KnowledgeGraph> {
+  async searchNodes(query: string, projectId?: string): Promise<KnowledgeGraph> {
     const graph = await this.loadGraph();
     const lowerQuery = query.toLowerCase();
-    const filteredEntities = graph.entities.filter(e =>
+    const normalizedProject = projectId?.trim().toLowerCase();
+
+    // First filter: match by name, type, or observation content
+    let filteredEntities = graph.entities.filter(e =>
       e.name.toLowerCase().includes(lowerQuery) ||
       e.entityType.toLowerCase().includes(lowerQuery) ||
       e.observations.some(o => o.content.toLowerCase().includes(lowerQuery))
     );
+
+    // Second filter: restrict to project + globals if a projectId was given
+    if (normalizedProject) {
+      filteredEntities = filteredEntities.filter(e =>
+        e.project === normalizedProject || e.project === null
+      );
+    }
+
     const filteredEntityNames = new Set(filteredEntities.map(e => e.name));
+    // When project-filtered, use AND logic (both endpoints must be in the result set)
+    // to avoid leaking cross-project relations. Without a project filter, use OR
+    // logic (at least one endpoint matches) for backward compatibility.
     const filteredRelations = graph.relations.filter(r =>
-      filteredEntityNames.has(r.from) || filteredEntityNames.has(r.to)
+      normalizedProject
+        ? filteredEntityNames.has(r.from) && filteredEntityNames.has(r.to)
+        : filteredEntityNames.has(r.from) || filteredEntityNames.has(r.to)
     );
     return { entities: filteredEntities, relations: filteredRelations };
   }
 
   /**
-   * Retrieves specific entities by exact name match. Includes relations where
-   * at least one endpoint is in the requested set.
+   * Retrieves specific entities by exact name match. Optionally filters by project
+   * (only returns entities in the specified project or global).
+   * Returns matching entities plus relations where both endpoints are in the result set.
+   *
+   * @param names - Array of entity name strings to retrieve
+   * @param projectId - Optional project name; only returns entities in this project or global
+   * @returns KnowledgeGraph with matching entities and connected relations
    */
-  async openNodes(names: string[]): Promise<KnowledgeGraph> {
+  async openNodes(names: string[], projectId?: string): Promise<KnowledgeGraph> {
     const graph = await this.loadGraph();
     const nameSet = new Set(names);
-    const filteredEntities = graph.entities.filter(e => nameSet.has(e.name));
+    const normalizedProject = projectId?.trim().toLowerCase();
+
+    // First filter: match by name
+    let filteredEntities = graph.entities.filter(e => nameSet.has(e.name));
+
+    // Second filter: restrict to project + globals if a projectId was given
+    if (normalizedProject) {
+      filteredEntities = filteredEntities.filter(e =>
+        e.project === normalizedProject || e.project === null
+      );
+    }
+
     const filteredEntityNames = new Set(filteredEntities.map(e => e.name));
+    // When project-filtered, use AND logic (both endpoints must be in the result set)
+    // to avoid leaking cross-project relations. Without a project filter, use OR
+    // logic (at least one endpoint matches) for backward compatibility.
     const filteredRelations = graph.relations.filter(r =>
-      filteredEntityNames.has(r.from) || filteredEntityNames.has(r.to)
+      normalizedProject
+        ? filteredEntityNames.has(r.from) && filteredEntityNames.has(r.to)
+        : filteredEntityNames.has(r.from) || filteredEntityNames.has(r.to)
     );
     return { entities: filteredEntities, relations: filteredRelations };
+  }
+
+  /**
+   * Lists all distinct project names that have at least one entity.
+   * Global entities (project === null) are excluded from the list.
+   *
+   * @returns Sorted array of project name strings
+   */
+  async listProjects(): Promise<string[]> {
+    const graph = await this.loadGraph();
+    const projects = new Set<string>();
+    for (const e of graph.entities) {
+      if (e.project !== null) projects.add(e.project);
+    }
+    return [...projects].sort();
   }
 }

--- a/jsonl-store.ts
+++ b/jsonl-store.ts
@@ -127,6 +127,13 @@ export class JsonlStore implements GraphStore {
               console.error(`Skipping entity with missing/invalid fields: ${JSON.stringify(item).substring(0, 100)}`);
               continue;
             }
+            // Warn if project is present but not a string (e.g., "project": 42).
+            // Unlike invalid name/entityType which skip the entity entirely,
+            // a non-string project silently becomes null (global). Log so the
+            // user knows their project annotation was discarded.
+            if (item.project != null && typeof item.project !== 'string') {
+              console.error(`Warning: entity "${item.name}" has non-string project value (${typeof item.project}), treating as global`);
+            }
             graph.entities.push({
               name: item.name,
               entityType: item.entityType,
@@ -198,7 +205,7 @@ export class JsonlStore implements GraphStore {
   async createEntities(entities: EntityInput[], projectId?: string): Promise<CreateEntitiesResult> {
     const graph = await this.loadGraph();
     // Normalize the project ID: trim whitespace, lowercase, or null for global
-    const normalizedProject = projectId?.trim().toLowerCase() || null;
+    const normalizedProject = projectId?.trim().toLowerCase().normalize('NFC') || null;
 
     const normalized: Entity[] = entities.map(e => ({
       name: e.name,
@@ -329,7 +336,7 @@ export class JsonlStore implements GraphStore {
     const graph = await this.loadGraph();
     if (!projectId) return graph;
 
-    const normalizedProject = projectId.trim().toLowerCase();
+    const normalizedProject = projectId.trim().toLowerCase().normalize('NFC');
     const filteredEntities = graph.entities.filter(e =>
       e.project === normalizedProject || e.project === null
     );
@@ -353,7 +360,7 @@ export class JsonlStore implements GraphStore {
   async searchNodes(query: string, projectId?: string): Promise<KnowledgeGraph> {
     const graph = await this.loadGraph();
     const lowerQuery = query.toLowerCase();
-    const normalizedProject = projectId?.trim().toLowerCase();
+    const normalizedProject = projectId?.trim().toLowerCase().normalize('NFC');
 
     // First filter: match by name, type, or observation content
     let filteredEntities = graph.entities.filter(e =>
@@ -393,7 +400,7 @@ export class JsonlStore implements GraphStore {
   async openNodes(names: string[], projectId?: string): Promise<KnowledgeGraph> {
     const graph = await this.loadGraph();
     const nameSet = new Set(names);
-    const normalizedProject = projectId?.trim().toLowerCase();
+    const normalizedProject = projectId?.trim().toLowerCase().normalize('NFC');
 
     // First filter: match by name
     let filteredEntities = graph.entities.filter(e => nameSet.has(e.name));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-memory-server",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "An MCP server that provides knowledge-graph-based persistent memory using entities, relations, and observations. Forked from @modelcontextprotocol/server-memory.",
   "license": "MIT",
   "author": "dustinspace217",

--- a/sqlite-store.ts
+++ b/sqlite-store.ts
@@ -135,13 +135,22 @@ export class SqliteStore implements GraphStore {
       );
     `);
 
-    // Migration: add project column if upgrading from an older schema.
-    // SQLite's ALTER TABLE ADD COLUMN is safe with IF NOT EXISTS via a try/catch.
-    try {
-      this.db.exec('ALTER TABLE entities ADD COLUMN project TEXT');
-    } catch {
-      // Column already exists -- safe to ignore "duplicate column name" error
+    // Migrate: add project column if upgrading from pre-Phase-3 schema.
+    // Uses pragma table_info to check if the column exists (spec-prescribed approach).
+    const columns = this.db.pragma('table_info(entities)') as { name: string }[];
+    const hasProject = columns.some(c => c.name === 'project');
+    if (!hasProject) {
+      this.db.exec(`
+        ALTER TABLE entities ADD COLUMN project TEXT;
+        CREATE INDEX IF NOT EXISTS idx_entities_project ON entities(project);
+      `);
     }
+
+    // Create the project index if it doesn't exist yet (idempotent).
+    // For new databases, the column is in CREATE TABLE but the index still needs creating.
+    // For migrated databases, the migration block above already created it,
+    // but IF NOT EXISTS makes this a safe no-op in that case.
+    this.db.exec('CREATE INDEX IF NOT EXISTS idx_entities_project ON entities(project);');
 
     // --- Run migration if data was loaded from JSONL ---
     if (migrationData) {
@@ -172,7 +181,7 @@ export class SqliteStore implements GraphStore {
   private migrateFromJsonl(graph: KnowledgeGraph): void {
     // Prepared statements are compiled once and reused for every row in the transaction
     const insertEntity = this.db.prepare(
-      'INSERT OR IGNORE INTO entities (name, entity_type) VALUES (?, ?)'
+      'INSERT OR IGNORE INTO entities (name, entity_type, project) VALUES (?, ?, ?)'
     );
     // Used to look up the auto-assigned id after inserting an entity
     const getEntityId = this.db.prepare(
@@ -189,7 +198,8 @@ export class SqliteStore implements GraphStore {
     const txn = this.db.transaction(() => {
       for (const entity of graph.entities) {
         // INSERT OR IGNORE: if name already exists (duplicate in JSONL), skip silently
-        insertEntity.run(entity.name, entity.entityType);
+        // entity.project comes from the JSONL data (null for pre-Phase-3 data)
+        insertEntity.run(entity.name, entity.entityType, entity.project ?? null);
         const row = getEntityId.get(entity.name) as { id: number };
         for (const obs of entity.observations) {
           // obs is already a normalized Observation object (JsonlStore.readGraph() calls normalizeObservation)

--- a/sqlite-store.ts
+++ b/sqlite-store.ts
@@ -146,11 +146,13 @@ export class SqliteStore implements GraphStore {
       `);
     }
 
-    // Create the project index if it doesn't exist yet (idempotent).
-    // For new databases, the column is in CREATE TABLE but the index still needs creating.
-    // For migrated databases, the migration block above already created it,
-    // but IF NOT EXISTS makes this a safe no-op in that case.
+    // Create indexes if they don't exist yet (idempotent).
+    // idx_entities_project: speeds up project-filtered entity queries.
+    // idx_relations_to_entity: the UNIQUE composite index on relations has from_entity
+    // as leftmost prefix, so from_entity IN (...) can use it. But to_entity IN (...)
+    // in getConnectedRelations needs its own index to avoid full table scans.
     this.db.exec('CREATE INDEX IF NOT EXISTS idx_entities_project ON entities(project);');
+    this.db.exec('CREATE INDEX IF NOT EXISTS idx_relations_to_entity ON relations(to_entity);');
 
     // --- Run migration if data was loaded from JSONL ---
     if (migrationData) {
@@ -197,9 +199,15 @@ export class SqliteStore implements GraphStore {
     // db.transaction() wraps everything in BEGIN/COMMIT and auto-rolls-back on throw
     const txn = this.db.transaction(() => {
       for (const entity of graph.entities) {
-        // INSERT OR IGNORE: if name already exists (duplicate in JSONL), skip silently
-        // entity.project comes from the JSONL data (null for pre-Phase-3 data)
-        insertEntity.run(entity.name, entity.entityType, entity.project ?? null);
+        // INSERT OR IGNORE: if name already exists (duplicate in JSONL), skip silently.
+        // Normalize the project value (trim + lowercase) to match the normalization
+        // applied by createEntities. Without this, mixed-case project values from JSONL
+        // (e.g., "My-Project") would be stored verbatim and become invisible to
+        // project-filtered queries that normalize to lowercase ("my-project").
+        const migratedProject = typeof entity.project === 'string'
+          ? entity.project.trim().toLowerCase() || null
+          : null;
+        insertEntity.run(entity.name, entity.entityType, migratedProject);
         const row = getEntityId.get(entity.name) as { id: number };
         for (const obs of entity.observations) {
           // obs is already a normalized Observation object (JsonlStore.readGraph() calls normalizeObservation)
@@ -249,8 +257,8 @@ export class SqliteStore implements GraphStore {
    * @returns CreateEntitiesResult with created entities and skipped duplicates
    */
   async createEntities(entities: EntityInput[], projectId?: string): Promise<CreateEntitiesResult> {
-    // Normalize the project ID: trim whitespace, lowercase, or null for global
-    const normalizedProject = projectId?.trim().toLowerCase() || null;
+    // Normalize the project ID: trim whitespace, lowercase, NFC normalize, or null for global
+    const normalizedProject = projectId?.trim().toLowerCase().normalize('NFC') || null;
 
     // Prepared statements are compiled once and reused -- faster than db.exec() per row
     const insertEntity = this.db.prepare(
@@ -528,7 +536,7 @@ export class SqliteStore implements GraphStore {
     let entityRows: { name: string; entityType: string; project: string | null }[];
 
     if (projectId) {
-      const normalizedProject = projectId.trim().toLowerCase();
+      const normalizedProject = projectId.trim().toLowerCase().normalize('NFC');
       // Return entities matching the project OR global entities (project IS NULL)
       entityRows = this.db.prepare(
         'SELECT name, entity_type AS entityType, project FROM entities WHERE project = ? OR project IS NULL'
@@ -542,18 +550,18 @@ export class SqliteStore implements GraphStore {
     const entities = this.buildEntities(entityRows);
 
     if (projectId) {
-      // When filtering by project, only include relations where both endpoints
-      // are in the filtered entity set (avoids dangling cross-project edges)
+      // When filtering by project, use getConnectedRelations to fetch only
+      // relations touching our entity set (SQL-level filtering via idx_relations_to_entity),
+      // then AND-filter to keep only relations where both endpoints are in the set
       const entityNames = new Set(entityRows.map(e => e.name));
-      const allRelations = this.db.prepare(
-        'SELECT from_entity AS "from", to_entity AS "to", relation_type AS relationType FROM relations'
-      ).all() as Relation[];
-      const filteredRelations = allRelations.filter(r =>
+      const connectedRelations = this.getConnectedRelations(entityRows.map(e => e.name));
+      const filteredRelations = connectedRelations.filter(r =>
         entityNames.has(r.from) && entityNames.has(r.to)
       );
       return { entities, relations: filteredRelations };
     }
 
+    // Unscoped: return all relations (backward compatible)
     const relations = this.db.prepare(
       'SELECT from_entity AS "from", to_entity AS "to", relation_type AS relationType FROM relations'
     ).all() as Relation[];
@@ -581,7 +589,7 @@ export class SqliteStore implements GraphStore {
     let entityRows: { name: string; entityType: string; project: string | null }[];
 
     if (projectId) {
-      const normalizedProject = projectId.trim().toLowerCase();
+      const normalizedProject = projectId.trim().toLowerCase().normalize('NFC');
       // Find entities matching the query AND belonging to the project or global
       entityRows = this.db.prepare(`
         SELECT DISTINCT e.name, e.entity_type AS entityType, e.project
@@ -636,7 +644,7 @@ export class SqliteStore implements GraphStore {
     let entityRows: { name: string; entityType: string; project: string | null }[];
 
     if (projectId) {
-      const normalizedProject = projectId.trim().toLowerCase();
+      const normalizedProject = projectId.trim().toLowerCase().normalize('NFC');
       const placeholders = names.map(() => '?').join(',');
       entityRows = this.db.prepare(
         `SELECT name, entity_type AS entityType, project FROM entities WHERE name IN (${placeholders}) AND (project = ? OR project IS NULL)`

--- a/sqlite-store.ts
+++ b/sqlite-store.ts
@@ -200,12 +200,13 @@ export class SqliteStore implements GraphStore {
     const txn = this.db.transaction(() => {
       for (const entity of graph.entities) {
         // INSERT OR IGNORE: if name already exists (duplicate in JSONL), skip silently.
-        // Normalize the project value (trim + lowercase) to match the normalization
+        // Normalize the project value (trim + lowercase + NFC) to match the normalization
         // applied by createEntities. Without this, mixed-case project values from JSONL
         // (e.g., "My-Project") would be stored verbatim and become invisible to
         // project-filtered queries that normalize to lowercase ("my-project").
+        // NFC normalization ensures macOS (NFD) and Linux (NFC) path-derived names match.
         const migratedProject = typeof entity.project === 'string'
-          ? entity.project.trim().toLowerCase() || null
+          ? entity.project.trim().toLowerCase().normalize('NFC') || null
           : null;
         insertEntity.run(entity.name, entity.entityType, migratedProject);
         const row = getEntityId.get(entity.name) as { id: number };

--- a/sqlite-store.ts
+++ b/sqlite-store.ts
@@ -15,6 +15,8 @@ import {
   type AddObservationInput,
   type DeleteObservationInput,
   type AddObservationResult,
+  type SkippedEntity,
+  type CreateEntitiesResult,
 } from './types.js';
 import { JsonlStore } from './jsonl-store.js';
 
@@ -109,11 +111,13 @@ export class SqliteStore implements GraphStore {
 
     // Create tables. IF NOT EXISTS makes this safe to call on an existing database.
     // entities.name has a UNIQUE constraint so it can be referenced by relations.
+    // project is nullable: NULL means global (visible to all projects).
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS entities (
         id          INTEGER PRIMARY KEY AUTOINCREMENT,
         name        TEXT NOT NULL UNIQUE,
-        entity_type TEXT NOT NULL
+        entity_type TEXT NOT NULL,
+        project     TEXT
       );
       CREATE TABLE IF NOT EXISTS observations (
         id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -130,6 +134,14 @@ export class SqliteStore implements GraphStore {
         UNIQUE(from_entity, to_entity, relation_type)
       );
     `);
+
+    // Migration: add project column if upgrading from an older schema.
+    // SQLite's ALTER TABLE ADD COLUMN is safe with IF NOT EXISTS via a try/catch.
+    try {
+      this.db.exec('ALTER TABLE entities ADD COLUMN project TEXT');
+    } catch {
+      // Column already exists -- safe to ignore "duplicate column name" error
+    }
 
     // --- Run migration if data was loaded from JSONL ---
     if (migrationData) {
@@ -217,34 +229,52 @@ export class SqliteStore implements GraphStore {
   }
 
   /**
-   * Creates new entities in the SQLite database.
+   * Creates new entities in the SQLite database, optionally scoped to a project.
    * Uses INSERT OR IGNORE to skip name-duplicates (both existing and within-batch).
    * Observations are inserted with INSERT OR IGNORE to deduplicate by (entity_id, content).
+   * Returns a CreateEntitiesResult with created entities and skipped duplicates.
    *
    * @param entities - Array of entities to create, each with observations as strings or objects
-   * @returns Only the entities that were actually created (excludes name-duplicates)
+   * @param projectId - Optional project name; normalized to lowercase/trimmed. Omit for global.
+   * @returns CreateEntitiesResult with created entities and skipped duplicates
    */
-  async createEntities(entities: EntityInput[]): Promise<Entity[]> {
+  async createEntities(entities: EntityInput[], projectId?: string): Promise<CreateEntitiesResult> {
+    // Normalize the project ID: trim whitespace, lowercase, or null for global
+    const normalizedProject = projectId?.trim().toLowerCase() || null;
+
     // Prepared statements are compiled once and reused -- faster than db.exec() per row
     const insertEntity = this.db.prepare(
-      'INSERT OR IGNORE INTO entities (name, entity_type) VALUES (?, ?)'
+      'INSERT OR IGNORE INTO entities (name, entity_type, project) VALUES (?, ?, ?)'
     );
     const getEntityId = this.db.prepare(
       'SELECT id FROM entities WHERE name = ?'
+    );
+    // Look up existing entity's project for skip reporting
+    const getExistingProject = this.db.prepare(
+      'SELECT project FROM entities WHERE name = ?'
     );
     const insertObs = this.db.prepare(
       'INSERT OR IGNORE INTO observations (entity_id, content, created_at) VALUES (?, ?, ?)'
     );
 
-    const results: Entity[] = [];
+    const created: Entity[] = [];
+    const skipped: SkippedEntity[] = [];
 
     // db.transaction() wraps the callback in BEGIN/COMMIT. If the callback throws,
     // it automatically rolls back. This is a better-sqlite3 feature (not raw SQL).
     const txn = this.db.transaction(() => {
       for (const e of entities) {
         // INSERT OR IGNORE returns changes=0 if the name already exists (UNIQUE constraint)
-        const info = insertEntity.run(e.name, e.entityType);
-        if (info.changes === 0) continue;
+        const info = insertEntity.run(e.name, e.entityType, normalizedProject);
+        if (info.changes === 0) {
+          // Entity already exists -- report it as skipped with its existing project
+          const existing = getExistingProject.get(e.name) as { project: string | null } | undefined;
+          skipped.push({
+            name: e.name,
+            existingProject: existing?.project ?? null,
+          });
+          continue;
+        }
 
         // Get the auto-generated id for inserting observations
         const row = getEntityId.get(e.name) as { id: number };
@@ -258,12 +288,12 @@ export class SqliteStore implements GraphStore {
           }
         }
 
-        results.push({ name: e.name, entityType: e.entityType, observations });
+        created.push({ name: e.name, entityType: e.entityType, observations, project: normalizedProject });
       }
     });
     txn();
 
-    return results;
+    return { created, skipped };
   }
 
   /**
@@ -401,10 +431,10 @@ export class SqliteStore implements GraphStore {
    * Uses a single query per chunk to fetch all observations (avoids N+1 queries).
    * Chunks the IN clause to stay within SQLite's SQLITE_MAX_VARIABLE_NUMBER limit (default 999).
    *
-   * @param entityRows - Array of { name, entityType } from an entities query
+   * @param entityRows - Array of { name, entityType, project } from an entities query
    * @returns Entity array with observations attached
    */
-  private buildEntities(entityRows: { name: string; entityType: string }[]): Entity[] {
+  private buildEntities(entityRows: { name: string; entityType: string; project: string | null }[]): Entity[] {
     if (entityRows.length === 0) return [];
 
     const names = entityRows.map(e => e.name);
@@ -433,6 +463,7 @@ export class SqliteStore implements GraphStore {
       name: e.name,
       entityType: e.entityType,
       observations: obsMap.get(e.name) || [],
+      project: e.project,
     }));
   }
 
@@ -475,15 +506,43 @@ export class SqliteStore implements GraphStore {
   }
 
   /**
-   * Returns the entire knowledge graph (all entities with observations, all relations).
-   * For an empty database, returns { entities: [], relations: [] }.
+   * Returns the knowledge graph, optionally filtered by project.
+   * When projectId is provided, returns entities belonging to that project
+   * plus global entities (project IS NULL). Relations are included only
+   * when both endpoints are in the filtered entity set.
+   * When projectId is omitted, returns the entire unfiltered graph.
+   *
+   * @param projectId - Optional project name to filter by; normalized to lowercase/trimmed
    */
-  async readGraph(): Promise<KnowledgeGraph> {
-    const entityRows = this.db.prepare(
-      'SELECT name, entity_type AS entityType FROM entities'
-    ).all() as { name: string; entityType: string }[];
+  async readGraph(projectId?: string): Promise<KnowledgeGraph> {
+    let entityRows: { name: string; entityType: string; project: string | null }[];
+
+    if (projectId) {
+      const normalizedProject = projectId.trim().toLowerCase();
+      // Return entities matching the project OR global entities (project IS NULL)
+      entityRows = this.db.prepare(
+        'SELECT name, entity_type AS entityType, project FROM entities WHERE project = ? OR project IS NULL'
+      ).all(normalizedProject) as { name: string; entityType: string; project: string | null }[];
+    } else {
+      entityRows = this.db.prepare(
+        'SELECT name, entity_type AS entityType, project FROM entities'
+      ).all() as { name: string; entityType: string; project: string | null }[];
+    }
 
     const entities = this.buildEntities(entityRows);
+
+    if (projectId) {
+      // When filtering by project, only include relations where both endpoints
+      // are in the filtered entity set (avoids dangling cross-project edges)
+      const entityNames = new Set(entityRows.map(e => e.name));
+      const allRelations = this.db.prepare(
+        'SELECT from_entity AS "from", to_entity AS "to", relation_type AS relationType FROM relations'
+      ).all() as Relation[];
+      const filteredRelations = allRelations.filter(r =>
+        entityNames.has(r.from) && entityNames.has(r.to)
+      );
+      return { entities, relations: filteredRelations };
+    }
 
     const relations = this.db.prepare(
       'SELECT from_entity AS "from", to_entity AS "to", relation_type AS relationType FROM relations'
@@ -495,54 +554,117 @@ export class SqliteStore implements GraphStore {
   /**
    * Searches entities by case-insensitive substring match against name, entityType,
    * or observation content. Uses LIKE with escaped wildcards.
+   * When projectId is provided, results are restricted to entities belonging to
+   * the project or global entities (project IS NULL).
    *
    * SQLite's LIKE is case-insensitive for ASCII characters (A-Z) by default.
    * For full Unicode case folding, FTS5 with ICU would be needed.
    *
    * @param query - The search string, matched as a case-insensitive substring
-   * @returns Matching entities + relations where at least one endpoint matches
+   * @param projectId - Optional project name; only returns entities in this project or global
+   * @returns Matching entities + relations where both endpoints are in the result set
    */
-  async searchNodes(query: string): Promise<KnowledgeGraph> {
+  async searchNodes(query: string, projectId?: string): Promise<KnowledgeGraph> {
     const escaped = escapeLike(query);
     const pattern = `%${escaped}%`;
 
-    // Find entities matching the query in name, type, or any observation content.
-    // LEFT JOIN ensures entities with no observations are still checked.
-    // DISTINCT prevents duplicates when multiple observations match.
-    const entityRows = this.db.prepare(`
-      SELECT DISTINCT e.name, e.entity_type AS entityType
-      FROM entities e
-      LEFT JOIN observations o ON o.entity_id = e.id
-      WHERE e.name LIKE ? ESCAPE '\\'
-         OR e.entity_type LIKE ? ESCAPE '\\'
-         OR o.content LIKE ? ESCAPE '\\'
-    `).all(pattern, pattern, pattern) as { name: string; entityType: string }[];
+    let entityRows: { name: string; entityType: string; project: string | null }[];
+
+    if (projectId) {
+      const normalizedProject = projectId.trim().toLowerCase();
+      // Find entities matching the query AND belonging to the project or global
+      entityRows = this.db.prepare(`
+        SELECT DISTINCT e.name, e.entity_type AS entityType, e.project
+        FROM entities e
+        LEFT JOIN observations o ON o.entity_id = e.id
+        WHERE (e.name LIKE ? ESCAPE '\\'
+           OR e.entity_type LIKE ? ESCAPE '\\'
+           OR o.content LIKE ? ESCAPE '\\')
+          AND (e.project = ? OR e.project IS NULL)
+      `).all(pattern, pattern, pattern, normalizedProject) as { name: string; entityType: string; project: string | null }[];
+    } else {
+      // No project filter -- search across all entities
+      entityRows = this.db.prepare(`
+        SELECT DISTINCT e.name, e.entity_type AS entityType, e.project
+        FROM entities e
+        LEFT JOIN observations o ON o.entity_id = e.id
+        WHERE e.name LIKE ? ESCAPE '\\'
+           OR e.entity_type LIKE ? ESCAPE '\\'
+           OR o.content LIKE ? ESCAPE '\\'
+      `).all(pattern, pattern, pattern) as { name: string; entityType: string; project: string | null }[];
+    }
 
     const entities = this.buildEntities(entityRows);
-    const relations = this.getConnectedRelations(entityRows.map(e => e.name));
+    // When project-filtered, use AND logic for relations (both endpoints in result set);
+    // when unfiltered, use OR logic (at least one endpoint matches) for backward compat
+    const entityNames = new Set(entityRows.map(e => e.name));
+    if (projectId) {
+      const allRelations = this.getConnectedRelations(entityRows.map(e => e.name));
+      const filteredRelations = allRelations.filter(r =>
+        entityNames.has(r.from) && entityNames.has(r.to)
+      );
+      return { entities, relations: filteredRelations };
+    }
 
+    const relations = this.getConnectedRelations(entityRows.map(e => e.name));
     return { entities, relations };
   }
 
   /**
    * Retrieves specific entities by exact name match. Returns matching entities
-   * plus relations where at least one endpoint is in the requested set.
+   * plus relations where both endpoints are in the result set.
    * Non-existent names are silently skipped.
+   * When projectId is provided, only returns entities in the project or global.
    *
    * @param names - Array of entity name strings to retrieve
+   * @param projectId - Optional project name; only returns entities in this project or global
    * @returns Matching entities with observations + connected relations
    */
-  async openNodes(names: string[]): Promise<KnowledgeGraph> {
+  async openNodes(names: string[], projectId?: string): Promise<KnowledgeGraph> {
     if (names.length === 0) return { entities: [], relations: [] };
 
-    const placeholders = names.map(() => '?').join(',');
-    const entityRows = this.db.prepare(
-      `SELECT name, entity_type AS entityType FROM entities WHERE name IN (${placeholders})`
-    ).all(...names) as { name: string; entityType: string }[];
+    let entityRows: { name: string; entityType: string; project: string | null }[];
+
+    if (projectId) {
+      const normalizedProject = projectId.trim().toLowerCase();
+      const placeholders = names.map(() => '?').join(',');
+      entityRows = this.db.prepare(
+        `SELECT name, entity_type AS entityType, project FROM entities WHERE name IN (${placeholders}) AND (project = ? OR project IS NULL)`
+      ).all(...names, normalizedProject) as { name: string; entityType: string; project: string | null }[];
+    } else {
+      const placeholders = names.map(() => '?').join(',');
+      entityRows = this.db.prepare(
+        `SELECT name, entity_type AS entityType, project FROM entities WHERE name IN (${placeholders})`
+      ).all(...names) as { name: string; entityType: string; project: string | null }[];
+    }
 
     const entities = this.buildEntities(entityRows);
-    const relations = this.getConnectedRelations(entityRows.map(e => e.name));
 
+    // When project-filtered, use AND logic for relations (both endpoints in result set);
+    // when unfiltered, use OR logic (at least one endpoint matches) for backward compat
+    if (projectId) {
+      const entityNames = new Set(entityRows.map(e => e.name));
+      const allRelations = this.getConnectedRelations(entityRows.map(e => e.name));
+      const filteredRelations = allRelations.filter(r =>
+        entityNames.has(r.from) && entityNames.has(r.to)
+      );
+      return { entities, relations: filteredRelations };
+    }
+
+    const relations = this.getConnectedRelations(entityRows.map(e => e.name));
     return { entities, relations };
+  }
+
+  /**
+   * Lists all distinct project names that have at least one entity.
+   * Global entities (project IS NULL) are excluded from the list.
+   *
+   * @returns Sorted array of project name strings
+   */
+  async listProjects(): Promise<string[]> {
+    const rows = this.db.prepare(
+      'SELECT DISTINCT project FROM entities WHERE project IS NOT NULL ORDER BY project'
+    ).all() as { project: string }[];
+    return rows.map(r => r.project);
   }
 }

--- a/types.ts
+++ b/types.ts
@@ -11,11 +11,13 @@ export interface Observation {
   createdAt: string;
 }
 
-/** A named node in the knowledge graph with a type and attached observations. */
+/** A named node in the knowledge graph with a type and attached observations.
+ *  project scopes the entity to a specific project (null = global, never undefined). */
 export interface Entity {
   name: string;
   entityType: string;
   observations: Observation[];
+  project: string | null;  // null = global, never undefined
 }
 
 /** A directed edge between two entities with a relation type. */
@@ -61,6 +63,20 @@ export type AddObservationResult = {
   addedObservations: Observation[];
 };
 
+/** An entity that was skipped during createEntities because its name
+ *  already exists (possibly in a different project). */
+export type SkippedEntity = {
+  name: string;
+  existingProject: string | null;
+};
+
+/** Return type for createEntities. Reports both created entities and
+ *  skipped duplicates with their owning project for collision feedback. */
+export type CreateEntitiesResult = {
+  created: Entity[];
+  skipped: SkippedEntity[];
+};
+
 /**
  * The GraphStore interface -- the contract both JsonlStore and SqliteStore implement.
  * Methods mirror the MCP tool operations. Return types use Readonly to prevent
@@ -73,15 +89,16 @@ export interface GraphStore {
   /** Cleanup: close DB connection. No-op for JSONL. */
   close(): Promise<void>;
 
-  createEntities(entities: EntityInput[]): Promise<Readonly<Entity[]>>;
+  createEntities(entities: EntityInput[], projectId?: string): Promise<Readonly<CreateEntitiesResult>>;
   createRelations(relations: Relation[]): Promise<Readonly<Relation[]>>;
   addObservations(observations: AddObservationInput[]): Promise<Readonly<AddObservationResult[]>>;
   deleteEntities(entityNames: string[]): Promise<void>;
   deleteObservations(deletions: DeleteObservationInput[]): Promise<void>;
   deleteRelations(relations: Relation[]): Promise<void>;
-  readGraph(): Promise<Readonly<KnowledgeGraph>>;
-  searchNodes(query: string): Promise<Readonly<KnowledgeGraph>>;
-  openNodes(names: string[]): Promise<Readonly<KnowledgeGraph>>;
+  readGraph(projectId?: string): Promise<Readonly<KnowledgeGraph>>;
+  searchNodes(query: string, projectId?: string): Promise<Readonly<KnowledgeGraph>>;
+  openNodes(names: string[], projectId?: string): Promise<Readonly<KnowledgeGraph>>;
+  listProjects(): Promise<string[]>;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds optional `projectId` parameter to `create_entities`, `read_graph`, `search_nodes`, and `open_nodes` tools for scoping operations to a project
- Entities with `project = null` (global) are visible to all project-scoped queries; entity names remain globally unique across projects
- New `list_projects` tool returns all distinct project names
- Collision reporting: `create_entities` returns `{ created, skipped }` with details on name conflicts
- Both `JsonlStore` and `SqliteStore` implement project filtering with consistent behavior
- Multi-layer project ID normalization: Zod `.trim()` → `normalizeProjectId()` (trim + lowercase + NFC) → store-level normalization
- Version bumped to 0.9.0

### Review fixes (F1–F7) from Discussion #28

Applied all findings from the 6-agent cross-examination review:

1. **F1**: Added `idx_relations_to_entity` index for OR-branch query performance in `getConnectedRelations`
2. **F2**: Switched `readGraph` to use `getConnectedRelations` with AND filter for project-scoped queries (was doing a full table scan + JS filter)
3. **F3**: Added `.trim()` to Zod `ProjectIdSchema` before `.min(1)` — rejects whitespace-only input at the schema boundary
4. **F4**: Normalized project values during `migrateFromJsonl` to prevent phantom UNIQUE constraint blockers
5. **F5**: Added tests verifying cross-project relations are excluded from `searchNodes` and `openNodes`
6. **F6**: Added `console.error` warning for non-string project values encountered during JSONL `loadGraph`
7. **F7**: Added `.normalize('NFC')` to all project normalization paths — ensures macOS (NFD) and Linux (NFC) path-derived project names map to the same scope

## Stats

- 7 files changed, +771 / -103
- 162 tests passing (147 shared + 14 JSONL-specific + 5 migration + 10 file-path — includes 2 new cross-project relation tests)

## Test plan

- [x] All 162 tests pass (`npm test`)
- [x] Whitespace-only projectId rejected by Zod (F3)
- [x] Cross-project relations excluded from scoped searchNodes/openNodes (F5)
- [x] `readGraph` with projectId uses indexed relation lookup instead of full scan (F1+F2)
- [x] JSONL→SQLite migration normalizes project values (F4)
- [x] Unicode NFC normalization consistent across all store methods (F7)
- [ ] Manual: start server with no env var, verify `memory.db` default works
- [ ] Manual: test with `MEMORY_FILE_PATH=memory.jsonl` to verify JSONL backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)